### PR TITLE
feat: initial work on error handling for the crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,61 @@ version = 3
 [[package]]
 name = "openid4vci"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"

--- a/crates/openid4vci/Cargo.toml
+++ b/crates/openid4vci/Cargo.toml
@@ -9,3 +9,4 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
+thiserror = "1.0.39"

--- a/crates/openid4vci/src/lib.rs
+++ b/crates/openid4vci/src/lib.rs
@@ -1,18 +1,15 @@
-//! Example project for now
+//! openid4vci specification implementation as a library.
+//!
+//! This library contains the following modules:
+//!
+//! ### Token
+//!
+//! The token module contains the code to do the following:
+//!
+//! - evaluate token requests
+//! - create token success responses
+//! - create token error responses
+//!
 
-/// Simple adder of usizes
-#[must_use]
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+/// Module that contains the functionality related to the token endpoint
+pub mod token;

--- a/crates/openid4vci/src/token/mod.rs
+++ b/crates/openid4vci/src/token/mod.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+/// Error enum for development when an error occurs related to the `Token` struct.
+#[derive(Error, Debug, PartialEq)]
+pub enum Error {
+    /// Error that is triggered when an [ErrorResponse] is instantiated with a name
+    /// that does not map to a value in the enum.
+    #[error("The name `{0}` is not a valid response name")]
+    InvalidErrorName(String),
+}
+
+/// Token structure which contains methods to create responses and evaluate input
+pub struct Token;
+
+#[cfg(test)]
+mod tests_token {
+    use super::*;
+
+    #[test]
+    fn should_convert_error_to_correct_message() {
+        let result = Error::InvalidErrorName("error_name".to_owned());
+        let expect = "The name `error_name` is not a valid response name";
+        assert_eq!(result.to_string(), expect);
+    }
+}


### PR DESCRIPTION
## Description

- Adds error handling to the `token` module/struct.

This PR adds a dependency on `thiserror`. A library that is great for dealing with errors in Rust when implementing it in a library. For a gRPC or any other service that would use this, we would use a crate like `eyre` or `anyhow` as they fit a different use case.

## Related issue(s)

## Checklist

- [x] Tests (unit, integration and e2e where relevant)
- [x] Documentation (in docs and within the code)
