### PR TITLE
feat: pre evaluate credential request

### DIFF
--- a/crates/openid4vci-grpc/proto/credential_issuer.proto
+++ b/crates/openid4vci-grpc/proto/credential_issuer.proto
@@ -3,10 +3,11 @@ syntax = "proto3";
 package openid4vci;
 
 service CredentialIssuerService {
-    rpc CreateOffer (CreateOfferRequest) returns (CreateOfferResponse);
+    rpc CreateCredentialOffer (CreateCredentialOfferRequest) returns (CreateCredentialOfferResponse);
+    rpc PreEvaluateCredentialRequest (PreEvaluateCredentialRequestRequest) returns (PreEvaluateCredentialRequestResponse);
 }
 
-message CreateOfferRequest {
+message CreateCredentialOfferRequest {
   bytes issuer_metadata = 1;
   bytes credentials = 2;
   optional string credential_offer_endpoint = 3;
@@ -14,7 +15,15 @@ message CreateOfferRequest {
   optional bytes pre_authorized_code_flow = 5;
 }
 
-message CreateOfferResponse {
+message CreateCredentialOfferResponse {
   bytes credential_offer = 1;
   bytes credential_offer_url = 2;
+}
+
+message PreEvaluateCredentialRequestRequest {
+  bytes credential_request = 1; 
+}
+
+message PreEvaluateCredentialRequestResponse {
+  optional string did = 1; 
 }

--- a/crates/openid4vci-grpc/src/lib.rs
+++ b/crates/openid4vci-grpc/src/lib.rs
@@ -38,7 +38,10 @@ mod utils;
 
 pub use grpc_openid4vci::credential_issuer_service_client as credential_issuer_client;
 pub use grpc_openid4vci::credential_issuer_service_server as credential_issuer_server;
-pub use grpc_openid4vci::{CreateOfferRequest, CreateOfferResponse};
+pub use grpc_openid4vci::{
+    CreateCredentialOfferRequest, CreateCredentialOfferResponse,
+    PreEvaluateCredentialRequestRequest, PreEvaluateCredentialRequestResponse,
+};
 
 pub use grpc_openid4vci::access_token_service_client as access_token_client;
 pub use grpc_openid4vci::access_token_service_server as access_token_server;

--- a/crates/openid4vci/src/credential_issuer/mod.rs
+++ b/crates/openid4vci/src/credential_issuer/mod.rs
@@ -259,6 +259,15 @@ pub struct CredentialOfferGrants {
 /// Structure that contains the functionality for the credential issuer
 pub struct CredentialIssuer;
 
+/// Return type of the [`CredentialIssuer::pre_evaluate_credential_request`]
+#[derive(Debug, Serialize, PartialEq, Eq, Default)]
+pub struct PreEvaluateCredentialRequestResponse {
+    /// The DID that needs resolution before [`CredentialIssuer::evaluate_credential_request`] is
+    /// called
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
+}
+
 /// Return type of the [`CredentialIssuer::evaluate_credential_request`]
 #[derive(Debug, Serialize, PartialEq, Eq, Default)]
 pub struct CredentialIssuerEvaluateRequestResponse {
@@ -344,6 +353,30 @@ impl CredentialIssuer {
         Ok((credential_offer, credential_offer_url))
     }
 
+    /// Pre evaluate the credential request
+    ///
+    /// This will check whether the [`CredentialRequest`] contains a DID as kid inside the JWT and
+    /// return the value that needs resolution
+    ///
+    /// # Errors
+    ///
+    /// - When the credential request is invalid
+    pub fn pre_evaluate_credential_request(
+        credential_request: &CredentialRequest,
+    ) -> CredentialIssuerResult<PreEvaluateCredentialRequestResponse> {
+        credential_request.validate()?;
+
+        let did = if let Some(CredentialRequestProof { jwt, .. }) = &credential_request.proof {
+            let jwt = ProofJwt::from_str(jwt)?;
+            jwt.validate()?;
+            jwt.extract_kid()?
+        } else {
+            None
+        };
+
+        Ok(PreEvaluateCredentialRequestResponse { did })
+    }
+
     /// Evaluate a credential request
     ///
     /// # Errors
@@ -359,6 +392,7 @@ impl CredentialIssuer {
     ) -> CredentialIssuerResult<CredentialIssuerEvaluateRequestResponse> {
         issuer_metadata.validate()?;
         credential_request.validate()?;
+
         if let Some(credential_offer) = credential_offer {
             credential_offer.validate()?;
         };
@@ -446,5 +480,62 @@ mod test_create_credential_offer {
             id: "id_one".to_owned(),
         });
         assert_eq!(result, expect);
+    }
+}
+
+#[cfg(test)]
+mod test_pre_evaluate_credential_request {
+    use crate::jwt::error::JwtError;
+
+    use super::*;
+
+    #[test]
+    fn happy_flow() {
+        let credential_request = CredentialRequest {
+        proof: Some(CredentialRequestProof {
+            proof_type: "jwt".to_owned(),
+            jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEva2V5cy8xIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCJ9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
+        }),
+        format: CredentialFormatProfile::LdpVc {
+            context: vec![],
+            types: vec![],
+            credential_subject: None,
+            order: None,
+        },
+    };
+
+        let response = CredentialIssuer::pre_evaluate_credential_request(&credential_request)
+            .expect("Unable to to pre evaluate the credential request");
+
+        assert_eq!(
+            response.did,
+            Some("did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1".to_owned())
+        );
+    }
+
+    #[test]
+    fn should_not_work_with_x5c() {
+        let credential_request = CredentialRequest {
+        proof: Some(CredentialRequestProof {
+            proof_type: "jwt".to_owned(),
+            jwt: "eyJqd2siOiJ1bmtub3duIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCJ9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
+        }),
+        format: CredentialFormatProfile::LdpVc {
+            context: vec![],
+            types: vec![],
+            credential_subject: None,
+            order: None,
+        },
+    };
+
+        let response =
+            CredentialIssuer::pre_evaluate_credential_request(&credential_request).unwrap_err();
+
+        assert_eq!(
+            response,
+            CredentialIssuerError::JwtError(JwtError::UnsupportedKeyTypeInJwtHeader {
+                key_type: "unknown".to_owned()
+            })
+        );
     }
 }

--- a/crates/openid4vci/src/jwt/error.rs
+++ b/crates/openid4vci/src/jwt/error.rs
@@ -115,6 +115,9 @@ pub enum JwtError {
     /// For now this includes: 'x5c' and 'jwk'
     #[error("Unsupported key type `{key_type}` found in JWT header")]
     UnsupportedKeyTypeInJwtHeader {
+        /// Name of the key used
+        key_name: String,
+
         /// Specified key type that is not supported
         key_type: String,
     },


### PR DESCRIPTION
Signed-off-by: blu3beri <blu3beri@proton.me>

## Description

Adds a `pre_evaluate_credential_request` method to be used before the `evaluate_credential_request` to see whether a DID needs to be resolved and passed in.

## Related issue(s)

## Checklist

- [ ] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
