### PR TITLE
feat: additional validation for credential request

### DIFF
--- a/crates/openid4vci-grpc/src/credential_issuer.rs
+++ b/crates/openid4vci-grpc/src/credential_issuer.rs
@@ -575,6 +575,8 @@ mod credential_issuer_tests {
                 c_nonce_expires_in: 1000,
                 c_nonce_created_at: Utc::now(),
             }),
+            issuer_id: Some("s6BhdRkqt3".to_owned()),
+            ..Default::default()
         };
 
         let options = serde_json::to_vec(&options).expect("Unable to serialize options");

--- a/crates/openid4vci/src/jwt/error.rs
+++ b/crates/openid4vci/src/jwt/error.rs
@@ -33,14 +33,14 @@ pub enum JwtError {
         now: DateTime<Utc>,
     } = 302,
 
-    /// Provided issuer, `client_id`, does not match the `iss` field
+    /// Provided issuer, `issuer_id`, does not match the `iss` field
     #[error("`iss` field in the body mismatched with provided issuer")]
     IssuerMismatch {
-        /// issuer id in the JWT
-        iss: Option<String>,
+        /// Supplied `iss`
+        expected_issuer: Option<String>,
 
-        /// User provided client id that must match the `iss`
-        client_id: Option<String>,
+        /// `iss` in the `JWT`
+        actual_issuer: Option<String>,
     } = 303,
 
     /// Could not find a specific key in the header
@@ -140,6 +140,16 @@ pub enum JwtError {
         /// Nonce in the `JWT`
         actual_nonce: String,
     } = 315,
+
+    /// Supplied subject did not match the subject inside the `JWT`
+    #[error("Expected subject was not found in the JWT")]
+    SubjectMismatch {
+        /// Supplied subject
+        expected_subject: Option<String>,
+
+        /// Subject in the `JWT`
+        actual_subject: Option<String>,
+    } = 316,
 }
 
 /// JWT result used for the [`JwtError`]


### PR DESCRIPTION
Signed-off-by: blu3beri <blu3beri@proton.me>

## Description

- Added validation for the `iss` and `sub` field inside the `JWT` proof. 
- We already threw an error when the credential offer is not supplied, so nothing changed there.

## Related issue(s)

## Checklist

- [x] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
