### PR TITLE
compare with spec

### DIFF
--- a/crates/openid4vci-grpc/src/credential_issuer.rs
+++ b/crates/openid4vci-grpc/src/credential_issuer.rs
@@ -575,6 +575,8 @@ mod credential_issuer_tests {
                 c_nonce_expires_in: 1000,
                 c_nonce_created_at: Utc::now(),
             }),
+            issuer_id: Some("s6BhdRkqt3".to_owned()),
+            ..Default::default()
         };
 
         let options = serde_json::to_vec(&options).expect("Unable to serialize options");

--- a/crates/openid4vci-grpc/src/credential_issuer.rs
+++ b/crates/openid4vci-grpc/src/credential_issuer.rs
@@ -488,7 +488,7 @@ mod credential_issuer_tests {
         });
 
         let issuer_metadata = serde_json::json!({
-            "credential_issuer": "test",
+            "credential_issuer": "https://server.example.com",
             "credential_endpoint": "https://example.org",
             "credentials_supported": [
                 &cfp
@@ -555,7 +555,7 @@ mod credential_issuer_tests {
             .expect("Unable to serialize credential request");
 
         let credential_offer = CredentialOffer {
-            credential_issuer: "me".to_owned(),
+            credential_issuer: "https://server.example.com".to_owned(),
             credentials: CredentialOrIds::new(vec![]),
             grants: CredentialOfferGrants {
                 authorized_code_flow: Some(AuthorizedCodeFlow { issuer_state: None }),
@@ -575,8 +575,7 @@ mod credential_issuer_tests {
                 c_nonce_expires_in: 1000,
                 c_nonce_created_at: Utc::now(),
             }),
-            issuer_id: Some("s6BhdRkqt3".to_owned()),
-            ..Default::default()
+            client_id: Some("s6BhdRkqt3".to_owned()),
         };
 
         let options = serde_json::to_vec(&options).expect("Unable to serialize options");
@@ -599,7 +598,13 @@ mod credential_issuer_tests {
         let response = match response {
             evaluate_credential_request_response::Response::Success(s) => s.proof_of_possession,
             evaluate_credential_request_response::Response::Error(e) => {
-                panic!("{:#?}", e.description)
+                let additional_information = e.additional_information();
+                let additional_information: serde_json::Value =
+                    deserialize_slice(additional_information).expect("Unable to deserialize");
+                panic!(
+                    "[ERROR]: {:#?} \n info: {:#?}",
+                    e.description, additional_information
+                );
             }
         };
 

--- a/crates/openid4vci/src/access_token/mod.rs
+++ b/crates/openid4vci/src/access_token/mod.rs
@@ -350,8 +350,6 @@ mod test_access_token_evaluate_request {
             Some(evaluate_access_token_request_options),
         );
 
-        println!("{output:?}");
-
         assert!(output.is_ok());
     }
 
@@ -360,12 +358,12 @@ mod test_access_token_evaluate_request {
         let access_token_request = AccessTokenRequest {
             grant_type: GrantType::PreAuthorizedCodeFlow {
                 pre_authorized_code: "0123".to_owned(),
-                user_pin: Some(123213),
+                user_pin: Some(123_213),
             },
         };
 
         let evaluate_access_token_request_options = EvaluateAccessTokenRequestOptions {
-            user_code: Some(123213),
+            user_code: Some(123_213),
         };
 
         let output = AccessToken::evaluate_access_token_request(

--- a/crates/openid4vci/src/jwt/error.rs
+++ b/crates/openid4vci/src/jwt/error.rs
@@ -33,14 +33,15 @@ pub enum JwtError {
         now: DateTime<Utc>,
     } = 302,
 
-    /// Provided issuer, `issuer_id`, does not match the `iss` field
-    #[error("`iss` field in the body mismatched with provided issuer")]
+    /// Provided issuer, `issuer_id`, does not match the `iss` field. The value of this claim MUST
+    /// be the client_id of the client making the credential request.
+    #[error("`iss` field in the body mismatched with provided client id")]
     IssuerMismatch {
-        /// Supplied `iss`
-        expected_issuer: Option<String>,
+        /// Supplied `client_id`
+        expected_iss_in_jwt: Option<String>,
 
         /// `iss` in the `JWT`
-        actual_issuer: Option<String>,
+        actual_iss_in_jwt: Option<String>,
     } = 303,
 
     /// Could not find a specific key in the header
@@ -141,14 +142,15 @@ pub enum JwtError {
         actual_nonce: String,
     } = 315,
 
-    /// Supplied subject did not match the subject inside the `JWT`
-    #[error("Expected subject was not found in the JWT")]
-    SubjectMismatch {
-        /// Supplied subject
-        expected_subject: Option<String>,
+    //// Supplied `credential_issuer_url` did not match the `aud` inside the `JWT`. The value of
+    ///this claim MUST be the Credential Issuer URL of the Credential Issuer.
+    #[error("`aud` field in the body mismatched with provided credential issuer url")]
+    AudienceMismatch {
+        /// Supplied `credential_issuer_url`
+        expected_aud_in_jwt: String,
 
-        /// Subject in the `JWT`
-        actual_subject: Option<String>,
+        /// `aud` in the `JWT`
+        actual_aud_in_jwt: String,
     } = 316,
 }
 

--- a/crates/openid4vci/src/jwt/error.rs
+++ b/crates/openid4vci/src/jwt/error.rs
@@ -33,14 +33,14 @@ pub enum JwtError {
         now: DateTime<Utc>,
     } = 302,
 
-    /// Provided issuer, `client_id`, does not match the `iss` field
+    /// Provided issuer, `issuer_id`, does not match the `iss` field
     #[error("`iss` field in the body mismatched with provided issuer")]
     IssuerMismatch {
-        /// issuer id in the JWT
-        iss: Option<String>,
+        /// Supplied `iss`
+        expected_issuer: Option<String>,
 
-        /// User provided client id that must match the `iss`
-        client_id: Option<String>,
+        /// `iss` in the `JWT`
+        actual_issuer: Option<String>,
     } = 303,
 
     /// Could not find a specific key in the header
@@ -140,6 +140,16 @@ pub enum JwtError {
         /// Nonce in the `JWT`
         actual_nonce: String,
     } = 315,
+
+    /// Supplied subject did not match the subject inside the `JWT`
+    #[error("Expected subject was not found in the JWT")]
+    SubjectMismatch {
+        /// Supplied subject
+        expected_subject: Option<String>,
+
+        /// Subject in the `JWT`
+        actual_subject: Option<String>,
+    } = 316,
 }
 
 /// JWT result used for the [`JwtError`]


### PR DESCRIPTION

## Description

- Validates the `iss` field in the `JWT` proof with the provided `client_id`
- Validates the `aud` field in the `JWT` proof with the provided `credential_issuer` from the `issuer_metadata`

## Related issue(s)

## Checklist

- [x] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
