### PR TITLE
feat: return recipient_id and credential after evaluation

### DIFF
--- a/crates/openid4vci-grpc/src/credential_issuer.rs
+++ b/crates/openid4vci-grpc/src/credential_issuer.rs
@@ -410,7 +410,7 @@ mod credential_issuer_tests {
     #[tokio::test]
     async fn should_pre_evaluate_request() {
         let expected = pre_evaluate_credential_request_response::Success {
-            did: Some("did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1".to_owned()),
+            did: Some("did:example:ebfeb1f712ebc6f1c276e12ec21".to_owned()),
         };
 
         let issuer = GrpcCredentialIssuer::default();

--- a/crates/openid4vci/src/credential_issuer/error.rs
+++ b/crates/openid4vci/src/credential_issuer/error.rs
@@ -88,6 +88,9 @@ pub enum CredentialIssuerError {
         /// Timestamp of when the nonce expires
         expiry_timestamp: DateTime<Utc>,
     } = 111,
+
+    #[error("The credential request does not contain a JWT proof")]
+    NoProofInCredentialRequest = 112,
 }
 
 error_impl!(CredentialIssuerError, CredentialIssuerResult);

--- a/crates/openid4vci/src/credential_issuer/mod.rs
+++ b/crates/openid4vci/src/credential_issuer/mod.rs
@@ -292,10 +292,16 @@ pub struct PreEvaluateCredentialRequestResponse {
 }
 
 /// Return type of the [`CredentialIssuer::evaluate_credential_request`]
-#[derive(Debug, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct CredentialIssuerEvaluateRequestResponse {
     /// Proof of possession, wrapping [`ProofOfPossession`]
     pub proof_of_possession: Option<ProofOfPossession>,
+
+    /// Identifier of the recipient. This identifier can be used when sending the credential.
+    pub subject_id: Option<String>,
+
+    /// The credential that should be issued afterwards to the `recipient_id`
+    pub credential: CredentialFormatProfile,
 }
 
 /// Structure that contains the items to check a proof of possession
@@ -462,7 +468,7 @@ impl CredentialIssuer {
         let did = if let Some(CredentialRequestProof { jwt, .. }) = &credential_request.proof {
             let jwt = ProofJwt::from_str(jwt)?;
             jwt.validate()?;
-            jwt.extract_kid()?
+            jwt.extract_did()?
         } else {
             None
         };
@@ -533,10 +539,12 @@ impl CredentialIssuer {
                     message,
                     signature,
                 }),
+                subject_id: jwt.extract_did()?,
+                credential: credential_request.format.clone(),
             });
-        };
+        }
 
-        Ok(CredentialIssuerEvaluateRequestResponse::default())
+        Err(CredentialIssuerError::NoProofInCredentialRequest)
     }
 
     /// Create a credential success response when all the previous steps are completed.
@@ -697,7 +705,7 @@ mod test_pre_evaluate_credential_request {
 
         assert_eq!(
             response.did,
-            Some("did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1".to_owned())
+            Some("did:example:ebfeb1f712ebc6f1c276e12ec21".to_owned())
         );
     }
 
@@ -785,19 +793,22 @@ mod test_evaluate_credential_request {
         .expect("Unable to create issuer metadata")
     }
 
+    fn valid_credential_format() -> CredentialFormatProfile {
+        CredentialFormatProfile::LdpVc {
+            context: vec![],
+            types: vec![],
+            credential_subject: None,
+            order: None,
+        }
+    }
+
     fn valid_credential_request() -> CredentialRequest {
         CredentialRequest {
          proof: Some(CredentialRequestProof {
              proof_type: "jwt".to_owned(),
              jwt: "ewogICJraWQiOiAiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgjejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwKICAiYWxnIjogIkVkRFNBIiwKICAidHlwIjogIm9wZW5pZDR2Y2ktcHJvb2Yrand0Igp9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
          }),
-         format: CredentialFormatProfile::LdpVc {
-             context: vec![],
-             types: vec![],
-             credential_subject: None,
-             order: None,
-         },
-     }
+         format:  valid_credential_format()   }
     }
 
     fn valid_authorized_server_metadata() -> AuthorizationServerMetadata {
@@ -900,6 +911,13 @@ mod test_evaluate_credential_request {
             Some(evaluate_credential_request_options),
         )
         .expect("Unable to evaluate credential request");
+
+        assert_eq!(
+            evaluated.subject_id,
+            Some("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".to_owned())
+        );
+
+        assert_eq!(evaluated.credential, valid_credential_format());
 
         let evaluated = evaluated
             .proof_of_possession

--- a/crates/openid4vci/src/jwt/mod.rs
+++ b/crates/openid4vci/src/jwt/mod.rs
@@ -184,7 +184,7 @@ impl ProofJwt {
     /// - When did could not be transformed
     /// - When `jwk` is used
     /// - When `x5c` is used
-    pub fn extract_kid(&self) -> JwtResult<Option<String>> {
+    pub fn extract_did(&self) -> JwtResult<Option<String>> {
         if let Some(header) = &self.header.additional_header {
             match header {
                 ProofJwtAdditionalHeader::KeyId(key_id) => {
@@ -195,7 +195,7 @@ impl ProofJwt {
                         }
                     })?;
 
-                    Ok(Some(did.to_string()))
+                    Ok(Some(did.did))
                 }
                 ProofJwtAdditionalHeader::Jwk(jwk) => {
                     Err(JwtError::UnsupportedKeyTypeInJwtHeader {


### PR DESCRIPTION
Signed-off-by: blu3beri <blu3beri@proton.me>

## Description

- Return the recipient_id after evaluation is called. The id is extracted from the `kid` in the proof.
- Return the credential that can be issued. It is extracted from the credential_request input parameter.

## Related issue(s)

## Checklist

- [x] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
