### PR TITLE
feat: improved grpc typing

### DIFF
--- a/crates/openid4vci-grpc/proto/access_token.proto
+++ b/crates/openid4vci-grpc/proto/access_token.proto
@@ -1,18 +1,27 @@
 syntax = "proto3";
 
 import "error.proto";
+import "types.proto";
 
 package openid4vci;
 
+// Service for working with access tokens. Can be used to evaluate access token requests,
+// and create access token responses.
 service AccessTokenService {
-  rpc CreateAccessTokenErrorResponse(CreateAccessTokenErrorResponseRequest)
-      returns (CreateAccessTokenErrorResponseResponse);
-  rpc CreateAccessTokenSuccessResponse(CreateAccessTokenSuccessResponseRequest)
-      returns (CreateAccessTokenSuccessResponseResponse);
+  // Evaluate an incoming access token request.
   rpc EvaluateAccessTokenRequest(EvaluateAccessTokenRequestRequest)
       returns (EvaluateAccessTokenRequestResponse);
+
+  // Create a successful access token response.
+  rpc CreateAccessTokenErrorResponse(CreateAccessTokenErrorResponseRequest)
+      returns (CreateAccessTokenErrorResponseResponse);
+
+  // Create an error access token response.
+  rpc CreateAccessTokenSuccessResponse(CreateAccessTokenSuccessResponseRequest)
+      returns (CreateAccessTokenSuccessResponseResponse);
 }
 
+// Request to create an access token error response.
 message CreateAccessTokenErrorResponseRequest {
   string error = 1;
   optional string error_description = 2;
@@ -20,6 +29,7 @@ message CreateAccessTokenErrorResponseRequest {
   optional bytes error_additional_details = 4;
 }
 
+// Response to create an access token error response.
 message CreateAccessTokenErrorResponseResponse {
   oneof response {
     Success success = 1;
@@ -27,21 +37,51 @@ message CreateAccessTokenErrorResponseResponse {
   }
 
   message Success {
-    bytes error_response = 1;
+    OAuthErrorResponse error_response = 1;
   }
 }
 
+// Request to create an access token success response.
+// NOTE: this message is a copy of `AccessTokenSuccessResponse`, but there's no inheritance
+// in proto, and it wouldn't be correct to use the same type (they're just the same at the moment)
 message CreateAccessTokenSuccessResponseRequest {
-  string access_token = 1;
-  string token_type = 2;
-  optional uint32 expires_in = 3;
-  optional string scope = 4;
-  optional string c_nonce = 5;
-  optional uint32 c_nonce_expires_in = 6;
-  optional bool authorization_pending = 7;
-  optional uint32 interval = 8;
+    // (OAuth2) The access token issued by the authorization server.
+    string access_token = 1;
+
+    // (OAuth2) The type of the token issued as described in Section 7.1 of the OAuth2 specification.
+    // Value is case insensitive.
+    string token_type = 2;
+
+    // (OAuth2) RECOMMENDED. The lifetime in seconds of the access token. For example, the value "3600"
+    // denotes that the access token will expire in one hour from the time the response was generated.
+    // If omitted, the authorization server SHOULD provide the expiration time via other means or
+    // document the default value.
+    optional uint32 expires_in = 3;
+
+    // (OAuth2) OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED.
+    // The scope of the access token as described by Section 3.3 of the OAuth2 Specification.
+    optional string scope = 4;
+
+    // Nonce to be used to create a proof of possession of key material when requesting a Credential
+    // (see Section 7.2). When received, the Wallet MUST use this nonce value for its subsequent
+    // credential requests until the Credential Issuer provides a fresh nonce.
+    optional string c_nonce = 5;
+
+    // The lifetime in seconds of the `c_nonce`
+    optional uint32 c_nonce_expires_in = 6;
+
+    // In the Pre-Authorized Code Flow, the Token Request is still pending as the Credential Issuer
+    // is waiting for the End-User interaction to complete. The client SHOULD repeat the Token Request.
+    // Before each new request, the client MUST wait at least the number of seconds specified by the
+    // `interval` response parameter.
+    optional bool authorization_pending = 7;
+
+    // The minimum amount of time in seconds that the client SHOULD wait between polling requests to the
+    // Token Endpoint in the Pre-Authorized Code Flow. If no value is provided, clients MUST use 5 as the default.
+    optional uint32 interval = 8;
 }
 
+// Response to create an access token success response.
 message CreateAccessTokenSuccessResponseResponse {
   oneof response {
     Success success = 1;
@@ -49,24 +89,74 @@ message CreateAccessTokenSuccessResponseResponse {
   }
 
   message Success {
-    bytes success_response = 1;
+    AccessTokenSuccessResponse success_response = 1;
     string created_at = 2;
   }
+
+  message AccessTokenSuccessResponse {
+    // (OAuth2) The access token issued by the authorization server.
+    string access_token = 1;
+
+    // (OAuth2) The type of the token issued as described in Section 7.1 of the OAuth2 specification.
+    // Value is case insensitive.
+    string token_type = 2;
+
+    // (OAuth2) RECOMMENDED. The lifetime in seconds of the access token. For example, the value "3600"
+    // denotes that the access token will expire in one hour from the time the response was generated.
+    // If omitted, the authorization server SHOULD provide the expiration time via other means or
+    // document the default value.
+    optional uint32 expires_in = 3;
+
+    // (OAuth2) OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED.
+    // The scope of the access token as described by Section 3.3 of the OAuth2 Specification.
+    optional string scope = 4;
+
+    // Nonce to be used to create a proof of possession of key material when requesting a Credential
+    // (see Section 7.2). When received, the Wallet MUST use this nonce value for its subsequent
+    // credential requests until the Credential Issuer provides a fresh nonce.
+    optional string c_nonce = 5;
+
+    // The lifetime in seconds of the `c_nonce`
+    optional uint32 c_nonce_expires_in = 6;
+
+    // In the Pre-Authorized Code Flow, the Token Request is still pending as the Credential Issuer
+    // is waiting for the End-User interaction to complete. The client SHOULD repeat the Token Request.
+    // Before each new request, the client MUST wait at least the number of seconds specified by the
+    // `interval` response parameter.
+    optional bool authorization_pending = 7;
+
+    // The minimum amount of time in seconds that the client SHOULD wait between polling requests to the
+    // Token Endpoint in the Pre-Authorized Code Flow. If no value is provided, clients MUST use 5 as the default.
+    optional uint32 interval = 8;
+  }
+
 }
 
+// Request to evaluate an access token request.
 message EvaluateAccessTokenRequestRequest {
   bytes access_token_request = 1;
   optional bytes credential_offer = 2;
-  optional bytes evaluate_access_token_request_options = 3;
+  optional EvaluateAccessTokenRequestOptions evaluate_access_token_request_options = 3;
+
+  message EvaluateAccessTokenRequestOptions { 
+    // Provided user code to validate against
+    optional uint64 user_code = 1;
+  }
 }
 
+// Response to evaluate an access token request.
 message EvaluateAccessTokenRequestResponse {
   oneof response {
     Success success = 1;
     Error error = 2;
   }
 
+  // Empty message (there's no fields in the response)
+  message EvaluateAccessTokenResponse {}
+
   message Success {
-    bytes success_response = 1;
+    EvaluateAccessTokenResponse success_response = 1;
   }
 }
+
+

--- a/crates/openid4vci-grpc/proto/credential_issuer.proto
+++ b/crates/openid4vci-grpc/proto/credential_issuer.proto
@@ -1,30 +1,49 @@
 syntax = "proto3";
 
 import "error.proto";
+import "credential_issuer_metadata.proto";
+import "credential_request.proto";
+import "types.proto";
 
 package openid4vci;
 
+// Service for working with credentials in OpenID4VCI. Can be used to create credential offers
+// evaluate credential requests, and create credential responses.
 service CredentialIssuerService {
+  // Create a credential offer.
   rpc CreateCredentialOffer(CreateCredentialOfferRequest)
       returns (CreateCredentialOfferResponse);
+
+  // Evaluate a credential request and return information about the request. 
   rpc EvaluateCredentialRequest(EvaluateCredentialRequestRequest)
       returns (EvaluateCredentialRequestResponse);
+
+  // Pre-evaluate a credential request. This is used for extracting some information
+  // from the credential request that is needed for full evaluation (as e.g. the evaluate
+  // methods need a did document, for which the did first needs to be extracted)
   rpc PreEvaluateCredentialRequest(PreEvaluateCredentialRequestRequest)
       returns (PreEvaluateCredentialRequestResponse);
-  rpc CreateCredentialErrorResponse(CreateCredentialErrorResponseRequest)
-      returns (CreateCredentialErrorResponseResponse);
+
+  // Create a credential success response for a credential request.
   rpc CreateCredentialSuccessResponse(CreateCredentialSuccessResponseRequest)
       returns (CreateCredentialSuccessResponseResponse);
+
+  // Create a credential error response for a credential request.
+  rpc CreateCredentialErrorResponse(CreateCredentialErrorResponseRequest)
+      returns (CreateCredentialErrorResponseResponse);
+
 }
 
+// Request to create a credential offer.
 message CreateCredentialOfferRequest {
-  bytes issuer_metadata = 1;
-  bytes credentials = 2;
+  CredentialIssuerMetadata issuer_metadata = 1;
+  repeated CredentialOrId credentials = 2;
   optional string credential_offer_endpoint = 3;
-  optional bytes authorized_code_flow = 4;
-  optional bytes pre_authorized_code_flow = 5;
+  optional AuthorizedCodeFlow authorized_code_flow = 4;
+  optional PreAuthorizedCodeFlow pre_authorized_code_flow = 5;
 }
 
+// Response to create a credential offer.
 message CreateCredentialOfferResponse {
   oneof response {
     Success success = 1;
@@ -37,10 +56,12 @@ message CreateCredentialOfferResponse {
   }
 }
 
+// Request to pre-evaluate a credential request.
 message PreEvaluateCredentialRequestRequest {
   bytes credential_request = 1;
 }
 
+// Response to pre-evaluate a credential request.
 message PreEvaluateCredentialRequestResponse {
   oneof response {
     Success success = 1;
@@ -52,34 +73,79 @@ message PreEvaluateCredentialRequestResponse {
   }
 }
 
+// Request to evaluate a credential request.
 message EvaluateCredentialRequestRequest {
-  bytes issuer_metadata = 1;
-  bytes credential_request = 2;
+  CredentialIssuerMetadata issuer_metadata = 1;
+  CredentialRequest credential_request = 2;
   optional bytes credential_offer = 3;
   optional bytes authorization_server_metadata = 4;
   optional bytes did_document = 5;
-  optional bytes evaluate_credential_request_options = 6;
+  optional EvaluateOptions evaluate_credential_request_options = 6;
+
+  message CNonceOptions {
+    // Lifetime of the nonce from Utc::now in seconds
+    uint32 c_nonce_expires_in = 1;
+
+    // Expected nonce in the `JWT`
+    string expected_c_nonce = 2;
+
+    // Timestamp of when the nonce was created
+    int64 c_nonce_created_at = 3;
+  }
+
+  // Additional options for validation of the credential request
+  message EvaluateOptions { 
+    // Additional nonce options for validation
+    optional CNonceOptions c_none = 1;
+  }
 }
 
+// Response to evaluate a credential request.
 message EvaluateCredentialRequestResponse {
   oneof response {
     Success success = 1;
     Error error = 2;
   }
 
+  message ProofOfPossesionResponse {
+    // (JWA) Algorithm used for signing
+    string algorithm = 1;
+
+    // Public key bytes that can be used for verification
+    bytes public_key = 2;
+
+    // Message that needs to be verified by the consumer
+    bytes message = 3;
+
+    // Signature over the message, using the public key, that can be used by the consumer to verify it
+    bytes signature = 4;
+  }
+
   message Success {
-    optional bytes proof_of_possession = 1;
+    optional ProofOfPossesionResponse proof_of_possession = 1;
   }
 }
 
+// Request to create a credential success response.
 message CreateCredentialSuccessResponseRequest {
-  bytes credential_request = 1;
+  CredentialRequest credential_request = 1;
+
+  // Contains issued Credential. MUST be present when `acceptance_token` is not returned
+  // Must be either a String or a JSON object, dependant on the `format` being requested in the credential request.
   optional bytes credential = 2;
+
+  // A JSON string containing a security token subsequently used to obtain a Credential. MUST be
+  // present when credential is not returned.
   optional string acceptance_token = 3;
+
+  // JSON string containing a nonce to be used to create a proof of possession of key material
   optional string c_nonce = 4;
+
+  // JSON integer denoting the lifetime in seconds of the c_nonce.
   optional uint32 c_nonce_expires_in = 5;
 }
 
+// Response to create a credential success response.
 message CreateCredentialSuccessResponseResponse {
   oneof response {
     Success success = 1;
@@ -87,11 +153,12 @@ message CreateCredentialSuccessResponseResponse {
   }
 
   message Success {
-    bytes success_response = 1;
+    CredentialSuccessResponse success_response = 1;
     string created_at = 2;
   }
 }
 
+// Request to create a credential error response.
 message CreateCredentialErrorResponseRequest {
   string error = 1;
   optional string error_description = 2;
@@ -99,6 +166,7 @@ message CreateCredentialErrorResponseRequest {
   optional bytes error_additional_details = 4;
 }
 
+// Response to create a credential error response.
 message CreateCredentialErrorResponseResponse {
   oneof response {
     Success success = 1;
@@ -106,6 +174,6 @@ message CreateCredentialErrorResponseResponse {
   }
 
   message Success {
-    bytes error_response = 1;
+    OAuthErrorResponse error_response = 1;
   }
 }

--- a/crates/openid4vci-grpc/proto/credential_issuer_metadata.proto
+++ b/crates/openid4vci-grpc/proto/credential_issuer_metadata.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package openid4vci;
 
-import "types.proto";
-
 // Struct mapping the `issuer_metadata` as defined in section 10.2.3 of the openid4vci specification.
 message CredentialIssuerMetadata {
   // The Credential Issuer's identifier
@@ -25,55 +23,4 @@ message CredentialIssuerMetadata {
   // NOTE: You can't really have dynamic properties in protobuf, and the type of each entry in credentials_supported changes
   // based on the value of the `format` field. So we just use a serialized JSON object here.
   repeated bytes credentials_supported = 5;
-}
-
-// Struct mapping the `credential_supported` as defined in section 10.2.3.1 of the openid4vci specification.
-message CredentialSupported {
-  // A JSON string identifying the format of this credential.
-  CredentialFormatProfile format = 1;
-
-  // A JSON string identifying the respective object.
-  // The value MUST be unique across all `credentials_supported` entries in the Credential Issuer Metadata.
-  optional string id = 2;
-
-  // Array of case-sensitive strings that identify how the Credential is bound to the identifier of the End-User.
-  /* optional */ repeated string cryptographic_binding_methods_supported = 3;
-
-  // Array of case-sensitive strings that identify the cryptographic suites that are supported for the cryptographic_binding_methods_supported.
-  /* optional */ repeated string cryptographic_suites_supported = 4;
-
-  // An array of objects containing the display properties of the supported credential for a certain language.
-  /* optional */ repeated DisplayProperties display = 5;
-}
-
-// Struct mapping the `display` type as defined in section 10.2.3.1 of the openid4vci specification.
-message DisplayProperties {
-  // Display name for the Credential.
-  string name = 1;
-
-  // String value that identifies the language of this object represented as a language tag taken from values defined in BCP47.
-  // Multiple display objects MAY be included for separate languages. There MUST be only one object with the same language identifier.
-  optional string locale = 2;
-
-  // A JSON object with information about the logo of the Credential.
-  optional DisplayLogo logo = 3;
-
-  // String value of a description of the Credential.
-  optional string description = 4;
-
-  // String value of a background color of the Credential represented as numerical color values defined in CSS Color Module Level 3.
-  optional string background_color = 5;
-
-  // String value of a text color of the Credential represented as numerical color values defined in CSS Color Module Level 3.
-  optional string text_color = 6;
-}
-
-
-// Struct mapping the `logo` type as defined in section 10.2.3.1 of the openid4vci specification.
-message DisplayLogo {
-  // URL where the Wallet can obtain a logo of the Credential from the Credential Issuer.
-  optional string url = 1;
-
-  // String value of an alternative text of a logo image.
-  optional string alt_text = 2;
 }

--- a/crates/openid4vci-grpc/proto/credential_issuer_metadata.proto
+++ b/crates/openid4vci-grpc/proto/credential_issuer_metadata.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package openid4vci;
+
+import "types.proto";
+
+// Struct mapping the `issuer_metadata` as defined in section 10.2.3 of the openid4vci specification.
+message CredentialIssuerMetadata {
+  // The Credential Issuer's identifier
+  string credential_issuer = 1;
+
+  // Identifier of the OAuth 2.0 Authorization Server the Credential Issuer relies on for authorization.
+  // If this element is omitted, the entity providing the Credential Issuer is also acting as the AS.
+  // The Credential Issuer's identifier is used as the OAuth 2.0 Issuer value to obtain the Authorization Server metadata.
+  optional string authorization_server = 2;
+
+  // URL of the Credential Issuer's Credential Endpoint.
+  string credential_endpoint = 3;
+
+  // URL of the Credential Issuer's Batch Credential Endpoint.
+  // If omitted, the Credential Issuer does not support the Batch Credential Endpoint.
+  optional string batch_credential_endpoint = 4;
+
+  // A JSON array containing a list of JSON objects, each representing metadata about a separate credential type.
+  // NOTE: You can't really have dynamic properties in protobuf, and the type of each entry in credentials_supported changes
+  // based on the value of the `format` field. So we just use a serialized JSON object here.
+  repeated bytes credentials_supported = 5;
+}
+
+// Struct mapping the `credential_supported` as defined in section 10.2.3.1 of the openid4vci specification.
+message CredentialSupported {
+  // A JSON string identifying the format of this credential.
+  CredentialFormatProfile format = 1;
+
+  // A JSON string identifying the respective object.
+  // The value MUST be unique across all `credentials_supported` entries in the Credential Issuer Metadata.
+  optional string id = 2;
+
+  // Array of case-sensitive strings that identify how the Credential is bound to the identifier of the End-User.
+  /* optional */ repeated string cryptographic_binding_methods_supported = 3;
+
+  // Array of case-sensitive strings that identify the cryptographic suites that are supported for the cryptographic_binding_methods_supported.
+  /* optional */ repeated string cryptographic_suites_supported = 4;
+
+  // An array of objects containing the display properties of the supported credential for a certain language.
+  /* optional */ repeated DisplayProperties display = 5;
+}
+
+// Struct mapping the `display` type as defined in section 10.2.3.1 of the openid4vci specification.
+message DisplayProperties {
+  // Display name for the Credential.
+  string name = 1;
+
+  // String value that identifies the language of this object represented as a language tag taken from values defined in BCP47.
+  // Multiple display objects MAY be included for separate languages. There MUST be only one object with the same language identifier.
+  optional string locale = 2;
+
+  // A JSON object with information about the logo of the Credential.
+  optional DisplayLogo logo = 3;
+
+  // String value of a description of the Credential.
+  optional string description = 4;
+
+  // String value of a background color of the Credential represented as numerical color values defined in CSS Color Module Level 3.
+  optional string background_color = 5;
+
+  // String value of a text color of the Credential represented as numerical color values defined in CSS Color Module Level 3.
+  optional string text_color = 6;
+}
+
+
+// Struct mapping the `logo` type as defined in section 10.2.3.1 of the openid4vci specification.
+message DisplayLogo {
+  // URL where the Wallet can obtain a logo of the Credential from the Credential Issuer.
+  optional string url = 1;
+
+  // String value of an alternative text of a logo image.
+  optional string alt_text = 2;
+}

--- a/crates/openid4vci-grpc/proto/credential_request.proto
+++ b/crates/openid4vci-grpc/proto/credential_request.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package openid4vci;
+
+import "types.proto";
+
+// Struct mapping the `credential_request` as defined in section 7.2 of the openid4vci specification
+message CredentialRequest {
+  // Format of the Credential to be issued. This Credential format identifier determines further
+  // parameters required to determine the type and (optionally) the content of the credential to
+  // be issued. Credential Format Profiles consisting of the Credential format specific set of
+  // parameters are defined in Appendix E of the openid4vci specification.
+  bytes format = 1;
+
+  // JSON object containing proof of possession of the key material the issued Credential shall
+  // be bound to. The specification envisions use of different types of proofs for different
+  // cryptographic schemes. The proof object MUST contain a proof_type claim of type JSON string
+  // denoting the concrete proof type. This type determines the further claims in the proof
+  // object and its respective processing rules. Proof types are defined in Section 7.2.1 of the
+  // openid4vci specification.
+  CredentialRequestProof proof = 2;
+}
+
+// Struct mapping of `proof types` as defined in section 7.2.1 of the openid4vci specification
+message CredentialRequestProof {
+  // Type of proof used. MUST be of string `jwt`.
+  string proof_type = 1;
+
+  // Objects of this type contain a single jwt element with a JWS
+  // [RFC7515](https://www.rfc-editor.org/rfc/rfc7515.txt) as proof of possession.
+  string jwt = 2;
+}

--- a/crates/openid4vci-grpc/proto/openid4vci.proto
+++ b/crates/openid4vci-grpc/proto/openid4vci.proto
@@ -3,5 +3,6 @@ syntax = "proto3";
 import "error.proto";
 import "access_token.proto";
 import "credential_issuer.proto";
-import "types.proto";
+import "credential_request.proto";
 import "credential_issuer_metadata.proto";
+import "types.proto";

--- a/crates/openid4vci-grpc/proto/openid4vci.proto
+++ b/crates/openid4vci-grpc/proto/openid4vci.proto
@@ -3,3 +3,5 @@ syntax = "proto3";
 import "error.proto";
 import "access_token.proto";
 import "credential_issuer.proto";
+import "types.proto";
+import "credential_issuer_metadata.proto";

--- a/crates/openid4vci-grpc/proto/types.proto
+++ b/crates/openid4vci-grpc/proto/types.proto
@@ -2,78 +2,66 @@ syntax = "proto3";
 
 package openid4vci;
 
-// Represents a credential format profile as defined in the Rust code.
-message CredentialFormatProfile {
-  // Format name for the profile.
+message AuthorizedCodeFlow {
+  // Issuer state that MUST be the same, if supplied, from the authorization request
+  optional string issuer_state = 1;
+}
+
+message PreAuthorizedCodeFlow {
+  // The code representing the Credential Issuer's authorization for the Wallet to obtain
+  // Credentials of a certain type. This code MUST be short lived and single-use. If the Wallet
+  // decides to use the Pre-Authorized Code Flow, this parameter value MUST be included in the
+  // subsequent Token Request with the Pre-Authorized Code Flow.
+  string code = 1;
+
+  // Boolean value specifying whether the Credential Issuer expects presentation of a user PIN
+  // along with the Token Request in a Pre-Authorized Code Flow. Default is false. This PIN is
+  // intended to bind the Pre-Authorized Code to a certain transaction in order to prevent
+  // replay of this code by an attacker that, for example, scanned the QR code while standing
+  // behind the legit user. It is RECOMMENDED to send a PIN via a separate channel. If the
+  // Wallet decides to use the Pre-Authorized Code Flow, a PIN value MUST be sent in the
+  // user_pin parameter with the respective Token Request.
+  optional bool user_pin_required = 2;
+}
+
+message CredentialOrId {
+    oneof credential_or_id {
+        bytes credential = 1;
+        string id = 2;
+    }
+}
+
+message CredentialSuccessResponse {
+  // JSON string denoting the format of the issued Credential.
   string format = 1;
-  // Union field profile can contain different profile types.
-  oneof profile {
-    JwtVcJson jwt_vc_json = 2;
-    JwtVcJsonLd jwt_vc_json_ld = 3;
-    LdpVc ldp_vc = 4;
-    MsoMdoc mso_mdoc = 5;
-  }
+
+  // Contains issued Credential. present when `acceptance_token` is not returned
+  // Must be either a String or a JSON object, dependant on the `format` being requested in the credential request.
+  optional bytes credential = 2;
+
+  // A JSON string containing a security token subsequently used to obtain a Credential. MUST be
+  // present when credential is not returned.
+  optional string acceptance_token = 3;
+
+  // JSON string containing a nonce to be used to create a proof of possession of key material
+  optional string c_nonce = 4;
+
+  // JSON integer denoting the lifetime in seconds of the c_nonce.
+  optional uint32 c_nonce_expires_in = 5;
 }
 
-// Profile type for VC signed as a JWT, not using JSON-LD.
-message JwtVcJson {
-  // Format name for the profile.
-  string format = 1;
+message OAuthErrorResponse {
+  // Error code indicating why the request failed.
+  string error = 1;
 
-  // Types supported by the credential type.
-  repeated string types = 2;
-  // Key-value pairs representing the claim offered in the Credential.
-  map<string, CredentialSubject> credential_subject = 3;
-  // Order in which claims should be displayed by the Wallet.
-  repeated string order = 4;
-}
+  // Human-readable ASCII text providing additional information
+  optional string error_description = 2;
 
-// Profile type for VC signed as a JWT, using JSON-LD.
-message JwtVcJsonLd {
-  // Types supported by the credential type.
-  repeated string types = 1;
-  // Key-value pairs representing the claim offered in the Credential.
-  map<string, CredentialSubject> credential_subject = 2;
-  // Order in which claims should be displayed by the Wallet.
-  repeated string order = 3;
-}
 
-// Profile type for VC secured using Data Integrity, using JSON-LD.
-message LdpVc {
-  // JSON-LD context for the credential.
-  repeated string context = 1;
-  // Types supported by the credential type.
-  repeated string types = 2;
-  // Key-value pairs representing the claim offered in the Credential.
-  map<string, CredentialSubject> credential_subject = 3;
-  // Order in which claims should be displayed by the Wallet.
-  repeated string order = 4;
-}
+  // A URI identifying a human-readable web page with information about the error,
+  optional string error_uri = 3;
 
-// Profile type for credentials complying with ISO.18013-5.
-message MsoMdoc {
-  // Identifier for the credential type.
-  string doctype = 1;
-  // Key-value pairs representing the claims offered in the Credential.
-  map<string, CredentialSubject> claims = 2;
-  // Order in which claims should be displayed by the Wallet.
-  repeated string order = 3;
-}
-
-// Represents the display properties of a claim in the Credential for a certain language.
-message CredentialSubjectDisplay {
-  // Display name for the claim.
-  optional string name = 1;
-  // Language identifier represented as language tag values defined in BCP47.
-  optional string locale = 2;
-}
-
-// Represents a claim offered in the Credential.
-message CredentialSubject {
-  // Boolean indicating whether the claim must be present in the Credential.
-  optional bool mandatory = 1;
-  // Type of the claim value.
-  string value_type = 2;
-  // Display properties of the claim in the Credential for different languages.
-  repeated CredentialSubjectDisplay display = 3;
+  // Optional additional details containing metadata about the error
+  // NOTE: these properties MUST be flattened into the root of the response object
+  optional bytes error_additional_details = 4;
 }

--- a/crates/openid4vci-grpc/proto/types.proto
+++ b/crates/openid4vci-grpc/proto/types.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package openid4vci;
+
+// Represents a credential format profile as defined in the Rust code.
+message CredentialFormatProfile {
+  // Format name for the profile.
+  string format = 1;
+  // Union field profile can contain different profile types.
+  oneof profile {
+    JwtVcJson jwt_vc_json = 2;
+    JwtVcJsonLd jwt_vc_json_ld = 3;
+    LdpVc ldp_vc = 4;
+    MsoMdoc mso_mdoc = 5;
+  }
+}
+
+// Profile type for VC signed as a JWT, not using JSON-LD.
+message JwtVcJson {
+  // Format name for the profile.
+  string format = 1;
+
+  // Types supported by the credential type.
+  repeated string types = 2;
+  // Key-value pairs representing the claim offered in the Credential.
+  map<string, CredentialSubject> credential_subject = 3;
+  // Order in which claims should be displayed by the Wallet.
+  repeated string order = 4;
+}
+
+// Profile type for VC signed as a JWT, using JSON-LD.
+message JwtVcJsonLd {
+  // Types supported by the credential type.
+  repeated string types = 1;
+  // Key-value pairs representing the claim offered in the Credential.
+  map<string, CredentialSubject> credential_subject = 2;
+  // Order in which claims should be displayed by the Wallet.
+  repeated string order = 3;
+}
+
+// Profile type for VC secured using Data Integrity, using JSON-LD.
+message LdpVc {
+  // JSON-LD context for the credential.
+  repeated string context = 1;
+  // Types supported by the credential type.
+  repeated string types = 2;
+  // Key-value pairs representing the claim offered in the Credential.
+  map<string, CredentialSubject> credential_subject = 3;
+  // Order in which claims should be displayed by the Wallet.
+  repeated string order = 4;
+}
+
+// Profile type for credentials complying with ISO.18013-5.
+message MsoMdoc {
+  // Identifier for the credential type.
+  string doctype = 1;
+  // Key-value pairs representing the claims offered in the Credential.
+  map<string, CredentialSubject> claims = 2;
+  // Order in which claims should be displayed by the Wallet.
+  repeated string order = 3;
+}
+
+// Represents the display properties of a claim in the Credential for a certain language.
+message CredentialSubjectDisplay {
+  // Display name for the claim.
+  optional string name = 1;
+  // Language identifier represented as language tag values defined in BCP47.
+  optional string locale = 2;
+}
+
+// Represents a claim offered in the Credential.
+message CredentialSubject {
+  // Boolean indicating whether the claim must be present in the Credential.
+  optional bool mandatory = 1;
+  // Type of the claim value.
+  string value_type = 2;
+  // Display properties of the claim in the Credential for different languages.
+  repeated CredentialSubjectDisplay display = 3;
+}

--- a/crates/openid4vci/src/error_response.rs
+++ b/crates/openid4vci/src/error_response.rs
@@ -17,7 +17,7 @@ where
     /// used to provide the client developer with additional information about the error.
     pub error_uri: Option<String>,
 
-    /// Optonal additional details containing metadata about the error
+    /// Optional additional details containing metadata about the error
     #[serde(flatten)]
     pub error_additional_details: Option<serde_json::Value>,
 }

--- a/crates/openid4vci/src/types/credential_issuer_metadata.rs
+++ b/crates/openid4vci/src/types/credential_issuer_metadata.rs
@@ -68,7 +68,7 @@ pub struct CredentialSupported {
     /// did:example. Support for all DID methods listed in Section 13 of
     /// [DID_Specification_Registries](https://www.w3.org/TR/did-spec-registries/) is indicated by
     /// sending a DID without any method-name.
-    pub cryptographic_binding_mehtods_supported: Option<Vec<String>>,
+    pub cryptographic_binding_methods_supported: Option<Vec<String>>,
 
     /// Array of case sensitive strings that identify the cryptographic suites that are supported
     /// for the cryptographic_binding_methods_supported. Cryptosuites for Credentials in jwt_vc


### PR DESCRIPTION
## Description

This PR extends the typing for the grpc layer. Only the proto files are extended as I wasn't 100% on the simples way to map the proto types to the rust structs (@blu3beri can you pick that up). I think we need to extend the grpc layer with more code to transform between the structs and proto files.

In addition, I came across quite some complexities in typing the different objects using proto. Here some notes on that:

The following types are still todo (and need to think about exactly how to do it, see comments below):
- Credential Offer
- Authorization Server Metadata

The following types have been defined, but will probably have issues down the line as they can too be extended based on credential format (see #37). A solution would be to define all properties for all formats on the payload, and leave it up to the caller, and the rust library to validate the combination of properties.
- CredentialRequest - this is a JSON object that has extra properties based on the format.

The following types haven't been defined as it's not possible to define them in proto3:
- Did Document
- Credential Format Profile

The following types have been modified from the type in the Rust library, so we can use them in proto3:
- CredentialOrId - this is now an array of objects, where it's either a Credential object, or an object with an id property (can't have a union type without wrapper). This is done in the input methods (as those don't have to follow the openid spec), but for a credential offer, we can't change the strucuture, as then it wouldn't be a valid credential offer anymore

So I think to make the grpc layer more of a first class citizen, I think we need to extend the typing with all the credential foramt specific stuff. However, I'm thinking whehter it may make it more complex to deal with, as if you now have the different objects as JSON, you will need to manually map it to the grpc properties. 

Another thing we could do is to make all objects from the spec untyped, but we make the input properties, options, response types typed (as long as it's not a 1:1 object from the spec). This way we can't have issues that we can't model the type using proto (as we can define our own structure), and the caller of the library doesn't have to map between JSON <-> proto for spec types.

We could then append `_json` to all those objects, to indicate it's raw json (so `credential_offer_json`, `credential_request_json`, etc..).

Maybe the SICPA team @chumbert @victormartinez-work (I don't know the other github usernames, so please tag them) can also chime in on what you would prefer. We're fine with going all the way in typing (as far is possible), but want to make sure that makes it easier for you

## Related issue(s)

## Checklist

- [ ] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
