### PR TITLE
fix: correct types for a JSON-ld context

### DIFF
--- a/crates/openid4vci/src/credential_issuer/mod.rs
+++ b/crates/openid4vci/src/credential_issuer/mod.rs
@@ -611,7 +611,9 @@ impl CredentialIssuer {
 
 #[cfg(test)]
 mod test_create_credential_offer {
-    use crate::credential_issuer::error::CredentialIssuerError;
+    use crate::{
+        credential_issuer::error::CredentialIssuerError, types::credential::LinkedDataContext,
+    };
 
     use super::*;
 
@@ -620,7 +622,7 @@ mod test_create_credential_offer {
         let (offer, url) = CredentialIssuer::create_offer(
             &CredentialIssuerMetadata::default(),
             vec![CredentialOrId::Credential(CredentialFormatProfile::LdpVc {
-                context: vec!["context_one".to_owned()],
+                context: vec![LinkedDataContext::String("context_one".to_owned())],
                 types: vec!["type_one".to_owned()],
                 credential_subject: None,
                 order: None,
@@ -673,9 +675,8 @@ mod test_create_credential_offer {
 
 #[cfg(test)]
 mod test_pre_evaluate_credential_request {
-    use crate::jwt::error::JwtError;
-
     use super::*;
+    use crate::jwt::error::JwtError;
 
     #[test]
     fn happy_flow() {
@@ -731,11 +732,9 @@ mod test_pre_evaluate_credential_request {
 
 #[cfg(test)]
 mod test_evaluate_credential_request {
-    use ssi_dids::Document;
-
-    use crate::jwt::error::JwtError;
-
     use super::*;
+    use crate::jwt::error::JwtError;
+    use ssi_dids::Document;
 
     fn valid_credential_format_profile() -> serde_json::Value {
         serde_json::json!({

--- a/crates/openid4vci/src/types/credential.rs
+++ b/crates/openid4vci/src/types/credential.rs
@@ -15,7 +15,7 @@ pub enum LinkedDataContext {
     String(String),
 
     /// Contains a mapping from term -> IRI which can be a string or any JSON
-    Map(HashMap<String, LinkedDataContext>),
+    Map(HashMap<String, serde_json::Value>),
 }
 
 /// A struct mapping a `credential` type as defined in Appendix E in the [openid4vci

--- a/crates/openid4vci/src/validate.rs
+++ b/crates/openid4vci/src/validate.rs
@@ -44,3 +44,23 @@ pub trait Validatable {
     /// - When the validation fails for the implementation
     fn validate(&self) -> Result<(), ValidationError>;
 }
+
+#[cfg(test)]
+mod test_validation {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Mock {
+        x: String,
+    }
+
+    #[test]
+    fn should_format_error_correctly() {
+        let j = "{\"hello\": \"world\"}";
+        let deserialize_error = serde_json::from_str::<Mock>(j).unwrap_err();
+        let validation_error: ValidationError = ValidationError::from(deserialize_error);
+
+        assert!(matches!(validation_error, ValidationError::Any { .. }));
+    }
+}


### PR DESCRIPTION
## Description

- `@context` field inside a JSON-LD object can now be: `list`,`map` and `string`.

## Related issue(s)

closes #43

## Checklist

- [ ] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
