### PR TITLE
fix: improved serde errors by providing a path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "ssi-dids",
  "ssi-jwk",
  "strum",
@@ -1323,6 +1324,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "strum",
  "thiserror",
  "tokio",
@@ -1684,6 +1686,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 

--- a/crates/openid4vci-grpc/Cargo.toml
+++ b/crates/openid4vci-grpc/Cargo.toml
@@ -16,6 +16,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tonic = "0.8.3"
 prost = "0.11.8"
 tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
+serde_path_to_error = "0.1.11"
 
 [build-dependencies]
 tonic-build = "0.8.4"

--- a/crates/openid4vci-grpc/src/utils.rs
+++ b/crates/openid4vci-grpc/src/utils.rs
@@ -7,7 +7,9 @@ pub fn deserialize_slice<T>(b: &[u8]) -> std::result::Result<T, GrpcError>
 where
     T: DeserializeOwned,
 {
-    serde_json::from_slice(b).map_err(|e| GrpcError::ValidationError(ValidationError::from(e)))
+    let deserializer = &mut serde_json::Deserializer::from_slice(b);
+    let data: Result<T, _> = serde_path_to_error::deserialize(deserializer);
+    data.map_err(|e| GrpcError::ValidationError(ValidationError::from(e)))
 }
 
 /// Optionally, Deserialize a slice into a structure and convert the error into a [`GrpcError`]

--- a/crates/openid4vci/Cargo.toml
+++ b/crates/openid4vci/Cargo.toml
@@ -18,3 +18,4 @@ ssi-dids = "=0.1.0"
 ssi-jwk = {version = "0.1.0", default-features = false }
 strum = { version = "0.24.1", features = ["derive"] }
 urlencoding = "2.1.2"
+serde_path_to_error = "0.1.11"

--- a/crates/openid4vci/src/validate.rs
+++ b/crates/openid4vci/src/validate.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[repr(u32)]
 #[serde(untagged)]
 pub enum ValidationError {
-    #[error("{validation_message}")]
+    #[error("An error occurred during validation, serialization or deserialization")]
     /// Any validation error occurred
     Any {
         /// Validation message that should help the user debug the issue
@@ -29,6 +29,14 @@ impl From<base64::DecodeError> for ValidationError {
 
 impl From<serde_json::Error> for ValidationError {
     fn from(e: serde_json::Error) -> Self {
+        ValidationError::Any {
+            validation_message: e.to_string(),
+        }
+    }
+}
+
+impl From<serde_path_to_error::Error<serde_json::Error>> for ValidationError {
+    fn from(e: serde_path_to_error::Error<serde_json::Error>) -> Self {
         ValidationError::Any {
             validation_message: e.to_string(),
         }


### PR DESCRIPTION
## Description

Serde errors now provide a JSON-path to the incorrect type. It is still not the desired output, but it one step closer.

## Related issue(s)

closes #42

## Checklist

- [ ] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
