### PR TITLE
feat: created seperate types for metadata items

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ services is done with gRPC.
 
 ### Pre-Authorized Issuance using `openid4vci`
 
-```ignore
+```sh
 +--------------+   +-----------+                                    +-------------------+
 | User         |   |   Wallet  |                                    | Credential Issuer |
 +--------------+   +-----------+                                    +-------------------+

--- a/crates/openid4vci-grpc/src/client.rs
+++ b/crates/openid4vci-grpc/src/client.rs
@@ -1,6 +1,9 @@
 //! Example client package
 
-use openid4vci::types::credential_request::{CredentialRequest, CredentialRequestProof};
+use openid4vci::types::credential_request::{
+    CredentialRequest, CredentialRequestFormat, CredentialRequestProof,
+};
+use openid4vci::types::ldp_vc::{self, CredentialDefinition};
 use openid4vci::validate::ValidationError;
 use openid4vci::Document;
 use openid4vci_grpc::access_token_client::AccessTokenServiceClient;
@@ -106,12 +109,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             proof_type: "jwt".to_owned(),
             jwt: "ewogICJraWQiOiAiZGlkOmtleTp6RG5hZXJEYVRGNUJYRWF2Q3JmUlpFazMxNmRwYkxzZlBEWjNXSjVoUlRQRlUyMTY5I3pEbmFlckRhVEY1QlhFYXZDcmZSWkVrMzE2ZHBiTHNmUERaM1dKNWhSVFBGVTIxNjkiLAogICJhbGciOiAiRWREU0EiLAogICJ0eXAiOiAib3BlbmlkNHZjaS1wcm9vZitqd3QiCn0.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
         }),
-        format: openid4vci::types::credential::CredentialFormatProfile::LdpVc {
-            context: vec![],
-            types: vec![],
-            credential_subject: None,
-            order: None,
-        },
+        format: CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest { credential_definition: CredentialDefinition {types
+        : vec![],context: vec![]}  }
+        ),
     };
     let credential_request = serde_json::to_vec(&credential_request)?;
 
@@ -150,12 +150,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             proof_type: "jwt".to_owned(),
             jwt: "ewogICJraWQiOiAiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgjejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwKICAiYWxnIjogIkVkRFNBIiwKICAidHlwIjogIm9wZW5pZDR2Y2ktcHJvb2Yrand0Igp9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
         }),
-        format: openid4vci::types::credential::CredentialFormatProfile::LdpVc {
-            context: vec![],
-            types: vec![],
-            credential_subject: None,
-            order: None,
-        },
+        format: CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest { credential_definition: CredentialDefinition { context: vec![], types: vec![] } })
+        ,
     };
     let credential_request = serde_json::to_vec(&credential_request)?;
 

--- a/crates/openid4vci/src/credential_issuer/error.rs
+++ b/crates/openid4vci/src/credential_issuer/error.rs
@@ -1,6 +1,6 @@
-use crate::jwt::error::JwtError;
-use crate::types::credential::CredentialFormatProfile;
+use crate::types::credential_request::CredentialRequestFormat;
 use crate::validate::ValidationError;
+use crate::{jwt::error::JwtError, types::credential_issuer_metadata::CredentialSupported};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use thiserror::Error;
@@ -46,10 +46,10 @@ pub enum CredentialIssuerError {
     #[error("Requested credential not found in issuer metadata")]
     InvalidRequestedCredential {
         /// Boxed, for size, requested credential format
-        requested_credential: Box<CredentialFormatProfile>,
+        requested_credential: Box<CredentialRequestFormat>,
 
         /// issuer supported credential formats
-        supported_formats: Vec<CredentialFormatProfile>,
+        supported_formats: Vec<CredentialSupported>,
     } = 105,
 
     #[error("`c_nonce_expires_in` is not valid anymore.")]
@@ -111,7 +111,10 @@ mod credential_issuer_error_tests {
 
         assert!(error_information.code == 100);
         assert!(error_information.name == "ValidationError");
-        assert!(error_information.description == "some error");
+        assert!(
+            error_information.description
+                == "An error occurred during validation, serialization or deserialization"
+        );
         assert!(
             error_information.additional_information
                 == Some(serde_json::json!({

--- a/crates/openid4vci/src/credential_issuer/mod.rs
+++ b/crates/openid4vci/src/credential_issuer/mod.rs
@@ -8,10 +8,14 @@ use crate::types::authorization_server_metadata::AuthorizationServerMetadata;
 use crate::types::credential::CredentialFormatProfile;
 use crate::types::credential::CredentialFormatProfileOrEncoded;
 use crate::types::credential_issuer_metadata::CredentialIssuerMetadata;
+use crate::types::credential_offer::CredentialOffer;
+use crate::types::credential_offer::CredentialOfferFormatOrId;
 use crate::types::credential_request::CredentialRequest;
 use crate::types::credential_request::CredentialRequestProof;
+use crate::types::grants::AuthorizedCodeFlow;
+use crate::types::grants::Grants;
+use crate::types::grants::PreAuthorizedCodeFlow;
 use crate::validate::Validatable;
-use crate::validate::ValidationError;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
@@ -30,222 +34,6 @@ pub mod error_code;
 /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-7.3.1)
 pub type CredentialIssuerErrorResponse = ErrorResponse<CredentialIssuerErrorCode>;
 
-/// Enum that defines a type which may contain a [`CredentialFormatProfile`] type or a string
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum CredentialOrId {
-    /// A URI referencing a credential object on the [`CredentialIssuerMetadata`]
-    CredentialId(String),
-
-    /// A full nested Credential object
-    Credential(CredentialFormatProfile),
-}
-
-impl Default for CredentialOrId {
-    fn default() -> Self {
-        Self::CredentialId(String::new())
-    }
-}
-
-impl CredentialOrId {
-    /// Resolve the id from the issuer metadata
-    ///
-    /// # Errors
-    ///
-    /// - when the id is not in the `credentials_supported` of the [`CredentialIssuerMetadata`]
-    pub fn resolve(
-        &self,
-        issuer_metadata: &CredentialIssuerMetadata,
-    ) -> CredentialIssuerResult<CredentialFormatProfile> {
-        match self {
-            Self::Credential(c) => Ok(c.clone()),
-            Self::CredentialId(s) => {
-                let credential = issuer_metadata
-                    .credentials_supported
-                    .iter()
-                    .find(|c| c.id == Some(s.to_string()))
-                    .map(|c| c.format.clone());
-
-                credential.ok_or_else(|| CredentialIssuerError::CredentialIdNotInIssuerMetadata {
-                    id: s.clone(),
-                })
-            }
-        }
-    }
-}
-
-/// Container structure for the a list of credentials or references to credentials
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct CredentialOrIds(Vec<CredentialOrId>);
-
-impl CredentialOrIds {
-    /// Construct a new list of credentials or references to credentials
-    #[must_use]
-    pub fn new(credential_or_ids: Vec<CredentialOrId>) -> Self {
-        Self(credential_or_ids)
-    }
-
-    /// Resolve all the identifiers
-    ///
-    /// # Errors
-    ///
-    /// - When the first id could not be resolved from the [`CredentialIssuerMetadata`]
-    pub fn resolve_all(
-        &self,
-        issuer_metadata: &CredentialIssuerMetadata,
-    ) -> CredentialIssuerResult<Vec<CredentialFormatProfile>> {
-        let mut format_profiles = vec![];
-        for credential in &self.0 {
-            let credential = credential.resolve(issuer_metadata)?;
-            format_profiles.push(credential);
-        }
-        Ok(format_profiles)
-    }
-}
-
-impl From<&[&CredentialOrId]> for CredentialOrIds {
-    fn from(val: &[&CredentialOrId]) -> Self {
-        let v = val.to_vec().iter().map(|c| (*c).clone()).collect();
-        CredentialOrIds::new(v)
-    }
-}
-
-impl<T> From<Vec<T>> for CredentialOrIds
-where
-    T: Into<CredentialOrId> + Clone,
-{
-    fn from(value: Vec<T>) -> Self {
-        Self::new(value.iter().map(|v| (*v).clone().into()).collect())
-    }
-}
-
-impl From<String> for CredentialOrId {
-    fn from(value: String) -> Self {
-        Self::CredentialId(value)
-    }
-}
-
-impl From<&str> for CredentialOrId {
-    fn from(value: &str) -> Self {
-        Self::CredentialId(value.to_owned())
-    }
-}
-
-impl From<CredentialFormatProfile> for CredentialOrId {
-    fn from(value: CredentialFormatProfile) -> Self {
-        Self::Credential(value)
-    }
-}
-
-/// Field that defined the optional values for when the authorized code flow is used
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct AuthorizedCodeFlow {
-    /// Issuer state that MUST be the same, if supplied, from the authorization request
-    pub issuer_state: Option<String>,
-}
-
-/// Field that defines the optional values for when the pre-authorized code flow is used
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct PreAuthorizedCodeFlow {
-    /// The code representing the Credential Issuer's authorization for the Wallet to obtain
-    /// Credentials of a certain type. This code MUST be short lived and single-use. If the Wallet
-    /// decides to use the Pre-Authorized Code Flow, this parameter value MUST be include in the
-    /// subsequent Token Request with the Pre-Authorized Code Flow.
-    #[serde(rename = "pre-authorized_code")]
-    pub code: String,
-
-    /// Boolean value specifying whether the Credential Issuer expects presentation of a user PIN
-    /// along with the Token Request in a Pre-Authorized Code Flow. Default is false. This PIN is
-    /// intended to bind the Pre-Authorized Code to a certain transaction in order to prevent
-    /// replay of this code by an attacker that, for example, scanned the QR code while standing
-    /// behind the legit user. It is RECOMMENDED to send a PIN via a separate channel. If the
-    /// Wallet decides to use the Pre-Authorized Code Flow, a PIN value MUST be sent in the
-    /// user_pin parameter with the respective Token Request.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_pin_required: Option<bool>,
-}
-
-/// Struct mapping the `credential offer parameters` as defined in section 4.1.1 of the [openid4vci
-/// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-4.1.1)
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
-pub struct CredentialOffer {
-    /// The URL of the Credential Issuer, the Wallet is requested to obtain one or more Credentials
-    /// from.
-    pub credential_issuer: String,
-
-    /// A JSON array, where every entry is a JSON object or a JSON string. If the entry is an
-    /// object, the object contains the data related to a certain credential type the Wallet MAY
-    /// request. Each object MUST contain a format Claim determining the format of the credential
-    /// to be requested and further parameters characterising the type of the credential to be
-    /// requested as defined in Appendix E. If the entry is a string, the string value MUST be one
-    /// of the id values in one of the objects in the credentials_supported Credential Issuer
-    /// metadata parameter. When processing, the Wallet MUST resolve this string value to the
-    /// respective object.
-    pub credentials: CredentialOrIds,
-
-    /// A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared
-    /// to process for this credential offer. Every grant is represented by a key and an object. The
-    /// key value is the Grant Type identifier, the object MAY contain parameters either determining
-    /// the way the Wallet MUST use the particular grant and/or parameters the Wallet MUST send with
-    /// the respective request(s). If grants is not present or empty, the Wallet MUST determine the
-    /// Grant Types the Credential Issuer's AS supports using the respective metadata. When multiple
-    /// grants are present, it's at the Wallet's discretion which one to use.
-    pub grants: CredentialOfferGrants,
-}
-
-impl Validatable for CredentialOffer {
-    fn validate(&self) -> Result<(), ValidationError> {
-        self.credentials.validate()?;
-        self.grants.validate()?;
-
-        Ok(())
-    }
-}
-
-/// TODO: implement if required
-impl Validatable for CredentialOrIds {
-    fn validate(&self) -> Result<(), ValidationError> {
-        Ok(())
-    }
-}
-
-impl Validatable for CredentialOfferGrants {
-    fn validate(&self) -> Result<(), ValidationError> {
-        Ok(())
-    }
-}
-
-impl CredentialOffer {
-    /// Constructor for a credential offer
-    #[must_use]
-    pub fn new(
-        credential_issuer: &str,
-        credentials: CredentialOrIds,
-        authorized_code_flow: &Option<AuthorizedCodeFlow>,
-        pre_authorized_code_flow: &Option<PreAuthorizedCodeFlow>,
-    ) -> Self {
-        Self {
-            credential_issuer: credential_issuer.to_owned(),
-            credentials,
-            grants: CredentialOfferGrants {
-                authorized_code_flow: authorized_code_flow.clone(),
-                pre_authorized_code_flow: pre_authorized_code_flow.clone(),
-            },
-        }
-    }
-
-    /// Convert the credential offer to a url-encoded string
-    ///
-    /// # Errors
-    ///
-    /// - When the structure could not url encoded
-    pub fn url_encode(&self) -> CredentialIssuerResult<String> {
-        let s = serde_json::to_string(self).map_err(ValidationError::from)?;
-        let url = urlencoding::encode(&s).into_owned();
-        Ok(url)
-    }
-}
-
 /// Enum value as a union for the input to either contain a [`CredentialFormatProfile`] or
 /// `acceptance_token`
 pub enum CredentialOrAcceptanceToken {
@@ -254,29 +42,6 @@ pub enum CredentialOrAcceptanceToken {
 
     /// Acceptance token
     AcceptanceToken(String),
-}
-
-/// A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared
-/// to process for this credential offer. Every grant is represented by a key and an object. The
-/// key value is the Grant Type identifier, the object MAY contain parameters either determining
-/// the way the Wallet MUST use the particular grant and/or parameters the Wallet MUST send with
-/// the respective request(s). If grants is not present or empty, the Wallet MUST determine the
-/// Grant Types the Credential Issuer's AS supports using the respective metadata. When multiple
-/// grants are present, it's at the Wallet's discretion which one to use.
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
-pub struct CredentialOfferGrants {
-    /// Adds support for the authorized code flow as defined in section 3.4 of the [openid4vci
-    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-3.4).
-    #[serde(skip_serializing_if = "Option::is_none", rename = "authorization_code")]
-    pub authorized_code_flow: Option<AuthorizedCodeFlow>,
-
-    /// Adds support for the pre-authorized code flow as defined in section 3.5 of the [openid4vci
-    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-3.5).
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        rename = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
-    )]
-    pub pre_authorized_code_flow: Option<PreAuthorizedCodeFlow>,
 }
 
 /// Structure that contains the functionality for the credential issuer
@@ -299,9 +64,6 @@ pub struct CredentialIssuerEvaluateRequestResponse {
 
     /// Identifier of the recipient. This identifier can be used when sending the credential.
     pub subject_id: Option<String>,
-
-    /// The credential that should be issued afterwards to the `recipient_id`
-    pub credential: CredentialFormatProfile,
 }
 
 /// Structure that contains the items to check a proof of possession
@@ -418,7 +180,7 @@ impl CredentialIssuer {
     ///
     pub fn create_offer(
         issuer_metadata: &CredentialIssuerMetadata,
-        credentials: impl Into<CredentialOrIds>,
+        credentials: Vec<CredentialOfferFormatOrId>,
         credential_offer_endpoint: &Option<String>,
         authorized_code_flow: &Option<AuthorizedCodeFlow>,
         pre_authorized_code_flow: &Option<PreAuthorizedCodeFlow>,
@@ -430,22 +192,19 @@ impl CredentialIssuer {
             return Err(CredentialIssuerError::AuthorizedFlowNotSupported);
         }
 
-        let credentials: CredentialOrIds = credentials.into();
-
-        // Resolve all the credential ids, if supplied
-        // This also checks if the credential is supported by the issuer
-        //
-        // The resulting value is omitted as we use this check for now that they all reference a
-        // credential inside the `issuer_metadata`
-        credentials.resolve_all(issuer_metadata)?;
+        for c in &credentials {
+            c.assert_id_in_issuer_metadata(issuer_metadata)?;
+        }
 
         // Create a credential offer based on the input
-        let credential_offer = CredentialOffer::new(
-            issuer_metadata.credential_issuer.as_str(),
+        let credential_offer = CredentialOffer {
+            credential_issuer: issuer_metadata.credential_issuer.clone(),
             credentials,
-            authorized_code_flow,
-            pre_authorized_code_flow,
-        );
+            grants: Grants {
+                authorized_code_flow: authorized_code_flow.clone(),
+                pre_authorized_code_flow: pre_authorized_code_flow.clone(),
+            },
+        };
 
         // url-encode the credential offer
         let credential_offer_url_encoded = credential_offer.url_encode()?;
@@ -509,7 +268,6 @@ impl CredentialIssuer {
 
         let credential_offer =
             credential_offer.ok_or(CredentialIssuerError::CredentialOfferMustBeSupplied)?;
-        credential_offer.validate()?;
 
         if let Some(authorization_server_metadata) = authorization_server_metadata {
             authorization_server_metadata.validate()?;
@@ -588,7 +346,6 @@ impl CredentialIssuer {
                     signature,
                 }),
                 subject_id: jwt.extract_did()?,
-                credential: credential_request.format.clone(),
             });
         }
 
@@ -667,22 +424,24 @@ impl CredentialIssuer {
 
 #[cfg(test)]
 mod test_create_credential_offer {
-    use crate::{
-        credential_issuer::error::CredentialIssuerError, types::credential::LinkedDataContext,
-    };
-
     use super::*;
+    use crate::{
+        credential_issuer::error::CredentialIssuerError,
+        types::{credential::LinkedDataContext, credential_offer::CredentialOfferFormat, ldp_vc},
+    };
 
     #[test]
     fn happy_flow() {
         let (offer, url) = CredentialIssuer::create_offer(
             &CredentialIssuerMetadata::default(),
-            vec![CredentialOrId::Credential(CredentialFormatProfile::LdpVc {
-                context: vec![LinkedDataContext::String("context_one".to_owned())],
-                types: vec!["type_one".to_owned()],
-                credential_subject: None,
-                order: None,
-            })],
+            vec![CredentialOfferFormatOrId::CredentialOfferFormat(
+                CredentialOfferFormat::LdpVc(ldp_vc::CredentialOffer {
+                    credential_definition: ldp_vc::CredentialDefinition {
+                        context: vec![LinkedDataContext::String("some_context".to_owned())],
+                        types: vec!["type_one".to_owned()],
+                    },
+                }),
+            )],
             &None,
             &None,
             &Some(PreAuthorizedCodeFlow {
@@ -692,7 +451,7 @@ mod test_create_credential_offer {
         )
         .expect("Unable to create the credential offer");
 
-        assert_eq!(url, "openid-credential-offer://credential_offer=%7B%22credential_issuer%22%3A%22%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22ldp_vc%22%2C%22%40context%22%3A%5B%22context_one%22%5D%2C%22types%22%3A%5B%22type_one%22%5D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22ABC%22%7D%7D%7D");
+        assert_eq!(url, "openid-credential-offer://credential_offer=%7B%22credential_issuer%22%3A%22%22%2C%22credentials%22%3A%5B%7B%22credentialDefinition%22%3A%7B%22%40context%22%3A%5B%22some_context%22%5D%2C%22types%22%3A%5B%22type_one%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22ABC%22%7D%7D%7D");
 
         assert_eq!(offer.credential_issuer, String::new());
 
@@ -704,7 +463,7 @@ mod test_create_credential_offer {
     fn should_error_when_using_authorized_flow() {
         let result = CredentialIssuer::create_offer(
             &CredentialIssuerMetadata::default(),
-            CredentialOrIds::new(vec![]),
+            vec![],
             &Some(String::default()),
             &Some(AuthorizedCodeFlow { issuer_state: None }),
             &None,
@@ -715,16 +474,20 @@ mod test_create_credential_offer {
 
     #[test]
     fn should_error_when_supplying_credential_id_that_is_not_in_issuer_metadata() {
+        let id = "id_one".to_owned();
+
         let result = CredentialIssuer::create_offer(
             &CredentialIssuerMetadata::default(),
-            vec!["id_one"],
+            vec![CredentialOfferFormatOrId::Id(id.clone())],
             &Some(String::default()),
             &None,
             &Some(PreAuthorizedCodeFlow::default()),
         );
-        let expect = Err(CredentialIssuerError::CredentialIdNotInIssuerMetadata {
-            id: "id_one".to_owned(),
-        });
+        let expect = Err(CredentialIssuerError::ValidationError(
+            ValidationError::Any {
+                validation_message: format!("id `{id}` not found in the issuer metadata"),
+            },
+        ));
         assert_eq!(result, expect);
     }
 }
@@ -732,7 +495,13 @@ mod test_create_credential_offer {
 #[cfg(test)]
 mod test_pre_evaluate_credential_request {
     use super::*;
-    use crate::jwt::error::JwtError;
+    use crate::{
+        jwt::error::JwtError,
+        types::{
+            credential_request::CredentialRequestFormat,
+            ldp_vc::{self, CredentialDefinition},
+        },
+    };
 
     #[test]
     fn happy_flow() {
@@ -741,12 +510,7 @@ mod test_pre_evaluate_credential_request {
             proof_type: "jwt".to_owned(),
             jwt: "eyJraWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEva2V5cy8xIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCJ9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
         }),
-        format: CredentialFormatProfile::LdpVc {
-            context: vec![],
-            types: vec![],
-            credential_subject: None,
-            order: None,
-        },
+        format: CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest {credential_definition: CredentialDefinition { context: vec![], types: vec![] }}),
     };
 
         let response = CredentialIssuer::pre_evaluate_credential_request(&credential_request)
@@ -765,12 +529,7 @@ mod test_pre_evaluate_credential_request {
             proof_type: "jwt".to_owned(),
             jwt: "eyJqd2siOiJ1bmtub3duIiwiYWxnIjoiRVMyNTYiLCJ0eXAiOiJvcGVuaWQ0dmNpLXByb29mK2p3dCJ9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned()
         }),
-        format: CredentialFormatProfile::LdpVc {
-            context: vec![],
-            types: vec![],
-            credential_subject: None,
-            order: None,
-        },
+        format: CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest {credential_definition: CredentialDefinition { context: vec![], types: vec![] }}),
     };
 
         let response =
@@ -789,7 +548,13 @@ mod test_pre_evaluate_credential_request {
 #[cfg(test)]
 mod test_evaluate_credential_request {
     use super::*;
-    use crate::jwt::error::JwtError;
+    use crate::{
+        jwt::error::JwtError,
+        types::{
+            credential_request::CredentialRequestFormat,
+            ldp_vc::{self, CredentialDefinition},
+        },
+    };
     use ssi_dids::Document;
 
     fn valid_credential_format_profile() -> serde_json::Value {
@@ -851,13 +616,13 @@ mod test_evaluate_credential_request {
         .expect("Unable to create issuer metadata")
     }
 
-    fn valid_credential_format() -> CredentialFormatProfile {
-        CredentialFormatProfile::LdpVc {
-            context: vec![],
-            types: vec![],
-            credential_subject: None,
-            order: None,
-        }
+    fn valid_credential_request_format() -> CredentialRequestFormat {
+        CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest {
+            credential_definition: CredentialDefinition {
+                types: vec![],
+                context: vec![],
+            },
+        })
     }
 
     fn valid_credential_request() -> CredentialRequest {
@@ -866,7 +631,7 @@ mod test_evaluate_credential_request {
              proof_type: "jwt".to_owned(),
              jwt: "ewogICJraWQiOiAiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgjejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwKICAiYWxnIjogIkVkRFNBIiwKICAidHlwIjogIm9wZW5pZDR2Y2ktcHJvb2Yrand0Igp9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
          }),
-         format:  valid_credential_format()   }
+         format:  valid_credential_request_format()   }
     }
 
     fn valid_authorized_server_metadata() -> AuthorizationServerMetadata {
@@ -910,7 +675,9 @@ mod test_evaluate_credential_request {
     fn valid_credential_offer() -> CredentialOffer {
         let (credential_offer, _) = CredentialIssuer::create_offer(
             &valid_issuer_metadata(),
-            vec!["UniversityDegree_JWT"],
+            vec![CredentialOfferFormatOrId::Id(
+                "UniversityDegree_JWT".to_owned(),
+            )],
             &Some(String::default()),
             &None,
             &Some(PreAuthorizedCodeFlow::default()),
@@ -990,8 +757,6 @@ mod test_evaluate_credential_request {
             Some("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH".to_owned())
         );
 
-        assert_eq!(evaluated.credential, valid_credential_format());
-
         let evaluated = evaluated
             .proof_of_possession
             .expect("No proof of possession found");
@@ -1022,7 +787,7 @@ mod test_evaluate_credential_request {
                 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 34, 44, 34, 115, 117, 98, 34, 58,
                 110, 117, 108, 108, 44, 34, 105, 97, 116, 34, 58, 34, 50, 48, 49, 56, 45, 48, 57,
                 45, 49, 52, 84, 50, 49, 58, 49, 57, 58, 49, 48, 90, 34, 44, 34, 110, 111, 110, 99,
-                101, 34, 58, 34, 116, 90, 105, 103, 110, 115, 110, 70, 98, 112, 34, 125
+                101, 34, 58, 34, 116, 90, 105, 103, 110, 115, 110, 70, 98, 112, 34, 125, 46
             ]
         );
 
@@ -1032,7 +797,7 @@ mod test_evaluate_credential_request {
                 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109, 34, 44, 34, 115, 117, 98, 34,
                 58, 110, 117, 108, 108, 44, 34, 105, 97, 116, 34, 58, 34, 50, 48, 49, 56, 45, 48,
                 57, 45, 49, 52, 84, 50, 49, 58, 49, 57, 58, 49, 48, 90, 34, 44, 34, 110, 111, 110,
-                99, 101, 34, 58, 34, 116, 90, 105, 103, 110, 115, 110, 70, 98, 112, 34, 125
+                99, 101, 34, 58, 34, 116, 90, 105, 103, 110, 115, 110, 70, 98, 112, 34, 125, 46
             ]
         );
     }
@@ -1213,7 +978,13 @@ mod test_evaluate_credential_request {
 #[cfg(test)]
 mod test_create_credential_success_response {
     use super::*;
-    use crate::base::base64url;
+    use crate::{
+        base::base64url,
+        types::{
+            credential_request::CredentialRequestFormat,
+            ldp_vc::{self, CredentialDefinition},
+        },
+    };
 
     #[test]
     fn should_create_success_response() {
@@ -1257,12 +1028,7 @@ mod test_create_credential_success_response {
              proof_type: "jwt".to_owned(),
              jwt: "ewogICJraWQiOiAiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgjejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwKICAiYWxnIjogIkVkRFNBIiwKICAidHlwIjogIm9wZW5pZDR2Y2ktcHJvb2Yrand0Igp9.eyJpc3MiOiJzNkJoZFJrcXQzIiwiYXVkIjoiaHR0cHM6Ly9zZXJ2ZXIuZXhhbXBsZS5jb20iLCJpYXQiOiIyMDE4LTA5LTE0VDIxOjE5OjEwWiIsIm5vbmNlIjoidFppZ25zbkZicCJ9".to_owned(),
          }),
-         format: CredentialFormatProfile::LdpVc {
-             context: vec![],
-             types: vec![],
-             credential_subject: None,
-             order: None,
-         },
+         format: CredentialRequestFormat::LdpVc(ldp_vc::CredentialRequest { credential_definition: CredentialDefinition {types: vec![],context: vec![]} }),
      };
 
         let credential = CredentialOrAcceptanceToken::Credential(

--- a/crates/openid4vci/src/error_response.rs
+++ b/crates/openid4vci/src/error_response.rs
@@ -11,13 +11,15 @@ where
 
     /// Human-readable ASCII text providing additional information,
     /// used to assist the client developer in understanding the error that occurred.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_description: Option<String>,
 
     /// A URI identifying a human-readable web page with information about the error,
     /// used to provide the client developer with additional information about the error.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_uri: Option<String>,
 
     /// Optonal additional details containing metadata about the error
-    #[serde(flatten)]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub error_additional_details: Option<serde_json::Value>,
 }

--- a/crates/openid4vci/src/jwt/mod.rs
+++ b/crates/openid4vci/src/jwt/mod.rs
@@ -128,9 +128,8 @@ impl TryInto<String> for &ProofJwt {
 
         jwt.push(s_header);
         jwt.push(s_body);
-        if let Some(s) = &self.signature {
-            jwt.push(s.clone());
-        }
+        let signature = self.signature.clone().unwrap_or_default();
+        jwt.push(signature);
 
         Ok(jwt.join("."))
     }

--- a/crates/openid4vci/src/types/credential.rs
+++ b/crates/openid4vci/src/types/credential.rs
@@ -7,6 +7,8 @@ use crate::{
     validate::{Validatable, ValidationError},
 };
 
+use super::{jwt_vc_json, jwt_vc_json_ld, ldp_vc, mso_mdoc};
+
 /// Linked data context used for JSON-LD credentials
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
@@ -166,6 +168,7 @@ impl Validatable for CredentialFormatProfile {
 /// format as specified in Appendix E of the [openid4vci
 /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#name-credential-format-profiles).
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(untagged)]
 pub enum CredentialFormatProfileOrEncoded {
     /// [`CredentialFormatProfile`]
     CredentialFormatProfile(CredentialFormatProfile),
@@ -194,10 +197,10 @@ impl CredentialFormatProfile {
     #[must_use]
     pub fn get_format_name(&self) -> String {
         let s = match self {
-            Self::JwtVcJson { .. } => "jwt_vc_json",
-            Self::JwtVcJsonLd { .. } => "jwt_vc_json-ld",
-            Self::LdpVc { .. } => "ldp_vc",
-            Self::MsoMdoc { .. } => "mso_mdoc",
+            Self::JwtVcJson { .. } => jwt_vc_json::CREDENTIAL_FORMAT_IDENTIFIER,
+            Self::JwtVcJsonLd { .. } => jwt_vc_json_ld::CREDENTIAL_FORMAT_IDENTIFIER,
+            Self::LdpVc { .. } => ldp_vc::CREDENTIAL_FORMAT_IDENTIFIER,
+            Self::MsoMdoc { .. } => mso_mdoc::CREDENTIAL_FORMAT_IDENTIFIER,
         };
 
         s.to_owned()

--- a/crates/openid4vci/src/types/credential_offer.rs
+++ b/crates/openid4vci/src/types/credential_offer.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+
+use crate::validate::{ValidationError, ValidationResult};
+
+use super::{
+    credential_issuer_metadata::CredentialIssuerMetadata, grants::Grants, jwt_vc_json,
+    jwt_vc_json_ld, ldp_vc, mso_mdoc,
+};
+
+/// Struct mapping the `credential offer parameters` as defined in section 4.1.1 of the [openid4vci
+/// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-4.1.1)
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct CredentialOffer {
+    /// The URL of the Credential Issuer, the Wallet is requested to obtain one or more Credentials
+    /// from.
+    pub credential_issuer: String,
+
+    /// A JSON array, where every entry is a JSON object or a JSON string. If the entry is an
+    /// object, the object contains the data related to a certain credential type the Wallet MAY
+    /// request. Each object MUST contain a format Claim determining the format of the credential
+    /// to be requested and further parameters characterising the type of the credential to be
+    /// requested as defined in Appendix E. If the entry is a string, the string value MUST be one
+    /// of the id values in one of the objects in the credentials_supported Credential Issuer
+    /// metadata parameter. When processing, the Wallet MUST resolve this string value to the
+    /// respective object.
+    pub credentials: Vec<CredentialOfferFormatOrId>,
+
+    /// A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared
+    /// to process for this credential offer. Every grant is represented by a key and an object. The
+    /// key value is the Grant Type identifier, the object MAY contain parameters either determining
+    /// the way the Wallet MUST use the particular grant and/or parameters the Wallet MUST send with
+    /// the respective request(s). If grants is not present or empty, the Wallet MUST determine the
+    /// Grant Types the Credential Issuer's AS supports using the respective metadata. When multiple
+    /// grants are present, it's at the Wallet's discretion which one to use.
+    pub grants: Grants,
+}
+
+impl CredentialOffer {
+    /// Convert the credential offer to a url-encoded string
+    ///
+    /// # Errors
+    ///
+    /// - When the structure could not url encoded
+    pub fn url_encode(&self) -> ValidationResult<String> {
+        let s = serde_json::to_string(self).map_err(ValidationError::from)?;
+        let url = urlencoding::encode(&s).into_owned();
+        Ok(url)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum CredentialOfferFormat {
+    /// `jwt_vc_json`
+    ///
+    /// VC signed as a JWT, not using JSON-LD
+    #[serde(rename = "jwt_vc_json")]
+    JwtVcJson(jwt_vc_json::CredentialOffer),
+
+    /// `jwt_vc_json-ld`
+    ///
+    /// VC signed as a JWT, using JSON-LD
+    #[serde(rename = "jwt_vc_json-ld")]
+    JwtVcJsonLd(jwt_vc_json_ld::CredentialOffer),
+
+    /// `ldp_vc`
+    ///
+    /// VC secured using Data Integrity, using JSON-LD, with proof suite requiring Linked Data
+    /// canonicalization
+    #[serde(rename = "ldp_vc")]
+    LdpVc(ldp_vc::CredentialOffer),
+
+    /// `mso_mdoc`
+    ///
+    /// Credential Format Profile for credentials complying with
+    /// [ISO.18013-5](https://www.iso.org/standard/69084.html)
+    #[serde(rename = "mso_mdoc")]
+    MsoMdoc(mso_mdoc::CredentialOffer),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(untagged)]
+pub enum CredentialOfferFormatOrId {
+    Id(String),
+    CredentialOfferFormat(CredentialOfferFormat),
+}
+
+impl CredentialOfferFormatOrId {
+    pub fn assert_id_in_issuer_metadata(
+        &self,
+        issuer_metadata: &CredentialIssuerMetadata,
+    ) -> Result<(), ValidationError> {
+        match self {
+            CredentialOfferFormatOrId::Id(id) => {
+                let ids: Vec<_> = issuer_metadata
+                    .credentials_supported
+                    .iter()
+                    .filter_map(|c| c.id.clone())
+                    .collect();
+
+                if ids.contains(id) {
+                    Ok(())
+                } else {
+                    Err(ValidationError::Any {
+                        validation_message: format!("id `{id}` not found in the issuer metadata"),
+                    })
+                }
+            }
+            // `true` is returned here, because when the offer is not referring to a credential by
+            // id, it does not have to be checked.
+            CredentialOfferFormatOrId::CredentialOfferFormat(_) => Ok(()),
+        }
+    }
+}

--- a/crates/openid4vci/src/types/credential_request.rs
+++ b/crates/openid4vci/src/types/credential_request.rs
@@ -1,4 +1,4 @@
-use super::credential::CredentialFormatProfile;
+use super::{jwt_vc_json, jwt_vc_json_ld, ldp_vc, mso_mdoc};
 use crate::{
     jwt::ProofJwt,
     validate::{Validatable, ValidationError},
@@ -22,7 +22,7 @@ pub struct CredentialRequest {
     /// parameters are defined in Appendix E of the [openid4vci
     /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#format_profiles).
     #[serde(flatten)]
-    pub format: CredentialFormatProfile,
+    pub format: CredentialRequestFormat,
 
     /// JSON object containing proof of possession of the key material the issued Credential shall
     /// be bound to. The specification envisions use of different types of proofs for different
@@ -31,7 +31,54 @@ pub struct CredentialRequest {
     /// object and its respective processing rules. Proof types are defined in Section 7.2.1 of the
     /// [openid4vci
     /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#proof_types).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub proof: Option<CredentialRequestProof>,
+}
+
+/// TODO
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[serde(tag = "format")]
+pub enum CredentialRequestFormat {
+    /// `jwt_vc_json`
+    ///
+    /// VC signed as a JWT, not using JSON-LD
+    #[serde(rename = "jwt_vc_json")]
+    JwtVcJson(jwt_vc_json::CredentialRequest),
+
+    /// `jwt_vc_json-ld`
+    ///
+    /// VC signed as a JWT, using JSON-LD
+    #[serde(rename = "jwt_vc_json-ld")]
+    JwtVcJsonLd(jwt_vc_json_ld::CredentialRequest),
+
+    /// `ldp_vc`
+    ///
+    /// VC secured using Data Integrity, using JSON-LD, with proof suite requiring Linked Data
+    /// canonicalization
+    #[serde(rename = "ldp_vc")]
+    LdpVc(ldp_vc::CredentialRequest),
+
+    /// `mso_mdoc`
+    ///
+    /// Credential Format Profile for credentials complying with
+    /// [ISO.18013-5](https://www.iso.org/standard/69084.html)
+    #[serde(rename = "mso_mdoc")]
+    MsoMdoc(mso_mdoc::CredentialRequest),
+}
+
+impl CredentialRequestFormat {
+    /// Get the format name for the `credential_request` format key.
+    #[must_use]
+    pub fn get_format_name(&self) -> String {
+        let name = match self {
+            CredentialRequestFormat::JwtVcJson(_) => jwt_vc_json::CREDENTIAL_FORMAT_IDENTIFIER,
+            CredentialRequestFormat::JwtVcJsonLd(_) => jwt_vc_json_ld::CREDENTIAL_FORMAT_IDENTIFIER,
+            CredentialRequestFormat::LdpVc(_) => ldp_vc::CREDENTIAL_FORMAT_IDENTIFIER,
+            CredentialRequestFormat::MsoMdoc(_) => mso_mdoc::CREDENTIAL_FORMAT_IDENTIFIER,
+        };
+
+        name.to_owned()
+    }
 }
 
 /// Struct mapping of `proof types` as defined in section 7.2.1 of the [openid4vci
@@ -39,17 +86,11 @@ pub struct CredentialRequest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CredentialRequestProof {
     /// Type of proof used. MUST be of string `jwt`.
-    #[serde(default = "default_proof_type")]
     pub proof_type: String,
 
     /// objects of this type contain a single jwt element with a JWS
     /// [RFC7515](https://www.rfc-editor.org/rfc/rfc7515.txt) as proof of possession.
     pub jwt: String,
-}
-
-/// Default for proof `proof_type` value
-fn default_proof_type() -> String {
-    JWT_PROOF_TYPE.to_owned()
 }
 
 impl Validatable for CredentialRequest {

--- a/crates/openid4vci/src/types/grants.rs
+++ b/crates/openid4vci/src/types/grants.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+/// A JSON object indicating to the Wallet the Grant Types the Credential Issuer's AS is prepared
+/// to process for this credential offer. Every grant is represented by a key and an object. The
+/// key value is the Grant Type identifier, the object MAY contain parameters either determining
+/// the way the Wallet MUST use the particular grant and/or parameters the Wallet MUST send with
+/// the respective request(s). If grants is not present or empty, the Wallet MUST determine the
+/// Grant Types the Credential Issuer's AS supports using the respective metadata. When multiple
+/// grants are present, it's at the Wallet's discretion which one to use.
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq, Clone)]
+pub struct Grants {
+    /// Adds support for the authorized code flow as defined in section 3.4 of the [openid4vci
+    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-3.4).
+    #[serde(skip_serializing_if = "Option::is_none", rename = "authorization_code")]
+    pub authorized_code_flow: Option<AuthorizedCodeFlow>,
+
+    /// Adds support for the pre-authorized code flow as defined in section 3.5 of the [openid4vci
+    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#section-3.5).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+    )]
+    pub pre_authorized_code_flow: Option<PreAuthorizedCodeFlow>,
+}
+
+/// Field that defined the optional values for when the authorized code flow is used
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, Eq)]
+pub struct AuthorizedCodeFlow {
+    /// Issuer state that MUST be the same, if supplied, from the authorization request
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer_state: Option<String>,
+}
+
+/// Field that defines the optional values for when the pre-authorized code flow is used
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, Eq)]
+pub struct PreAuthorizedCodeFlow {
+    /// The code representing the Credential Issuer's authorization for the Wallet to obtain
+    /// Credentials of a certain type. This code MUST be short lived and single-use. If the Wallet
+    /// decides to use the Pre-Authorized Code Flow, this parameter value MUST be include in the
+    /// subsequent Token Request with the Pre-Authorized Code Flow.
+    #[serde(rename = "pre-authorized_code")]
+    pub code: String,
+
+    /// Boolean value specifying whether the Credential Issuer expects presentation of a user PIN
+    /// along with the Token Request in a Pre-Authorized Code Flow. Default is false. This PIN is
+    /// intended to bind the Pre-Authorized Code to a certain transaction in order to prevent
+    /// replay of this code by an attacker that, for example, scanned the QR code while standing
+    /// behind the legit user. It is RECOMMENDED to send a PIN via a separate channel. If the
+    /// Wallet decides to use the Pre-Authorized Code Flow, a PIN value MUST be sent in the
+    /// user_pin parameter with the respective Token Request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_pin_required: Option<bool>,
+}

--- a/crates/openid4vci/src/types/jwt_vc_json.rs
+++ b/crates/openid4vci/src/types/jwt_vc_json.rs
@@ -1,0 +1,79 @@
+use super::credential::CredentialSubject;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The Credential format identifier is `jwt_vc_json`.
+pub const CREDENTIAL_FORMAT_IDENTIFIER: &str = "jwt_vc_json";
+
+/// The following additional Credential Issuer metadata are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialIssuerMetadata {
+    ///  JSON array designating the types a certain credential type supports according to
+    ///  [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.3.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+
+    /// An array of claims.display.name values that lists them in the order they should be
+    /// displayed by the Wallet.
+    pub order: Option<Vec<String>>,
+}
+
+/// The following additional claims are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialOffer {
+    /// JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    /// This claim contains the type values the Wallet shall request in the subsequent Credential
+    /// Request.
+    pub types: Vec<String>,
+}
+
+/// The following additional claims are defined for authorization details of type `openid_credential`
+/// and this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationDetails {
+    ///  JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    ///  specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    ///  This claim contains the type values the Wallet requests authorization for at the issuer.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+}
+
+/// The following additional parameters are defined for Credential Requests and this Credential
+/// format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRequest {
+    ///  JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    ///  specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    ///  This claim contains the type values the Wallet requests authorization for at the issuer.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+}
+
+/// The value of the credential claim in the Credential Response MUST be a JSON string. Credentials
+/// of this format are already a sequence of base64url-encoded values separated by period
+/// characters and MUST NOT be re-encoded.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialResponse(String);
+
+impl From<CredentialResponse> for String {
+    fn from(response: CredentialResponse) -> Self {
+        response.0
+    }
+}

--- a/crates/openid4vci/src/types/jwt_vc_json_ld.rs
+++ b/crates/openid4vci/src/types/jwt_vc_json_ld.rs
@@ -1,0 +1,79 @@
+use super::credential::CredentialSubject;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The Credential format identifier is `jwt_vc_json-ld`.
+pub const CREDENTIAL_FORMAT_IDENTIFIER: &str = "jwt_vc_json-ld";
+
+/// The following additional Credential Issuer metadata are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialIssuerMetadata {
+    ///  JSON array designating the types a certain credential type supports according to
+    ///  [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.3.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+
+    /// An array of claims.display.name values that lists them in the order they should be
+    /// displayed by the Wallet.
+    pub order: Option<Vec<String>>,
+}
+
+/// The following additional claims are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialOffer {
+    /// JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    /// specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    /// This claim contains the type values the Wallet shall request in the subsequent Credential
+    /// Request.
+    pub types: Vec<String>,
+}
+
+/// The following additional claims are defined for authorization details of type `openid_credential`
+/// and this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationDetails {
+    ///  JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    ///  specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    ///  This claim contains the type values the Wallet requests authorization for at the issuer.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+}
+
+/// The following additional parameters are defined for Credential Requests and this Credential
+/// format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRequest {
+    ///  JSON array as defined in [Appendix E.1.1.2 of the openid4vci
+    ///  specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#server_metadata_jwt_vc_json).
+    ///  This claim contains the type values the Wallet requests authorization for at the issuer.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    pub credential_subject: HashMap<String, CredentialSubject>,
+}
+
+/// The value of the credential claim in the Credential Response MUST be a JSON string. Credentials
+/// of this format are already a sequence of base64url-encoded values separated by period
+/// characters and MUST NOT be re-encoded.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialResponse(String);
+
+impl From<CredentialResponse> for String {
+    fn from(response: CredentialResponse) -> Self {
+        response.0
+    }
+}

--- a/crates/openid4vci/src/types/ldp_vc.rs
+++ b/crates/openid4vci/src/types/ldp_vc.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::credential::{CredentialSubject, LinkedDataContext};
+
+/// The Credential format identifier is `ldp_vc`.
+pub const CREDENTIAL_FORMAT_IDENTIFIER: &str = "ldp_vc";
+
+/// The following additional Credential Issuer metadata are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialIssuerMetadata {
+    /// JSON array as defined in [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.1.
+    #[serde(rename = "@context")]
+    pub context: Vec<LinkedDataContext>,
+
+    ///  JSON array designating the types a certain credential type supports according to
+    ///  [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.3.
+    pub types: Vec<String>,
+
+    /// A JSON object containing a list of key value pairs, where the key identifies the claim
+    /// offered in the Credential. The value MAY be a dictionary, which allows to represent the
+    /// full (potentially deeply nested) structure of the verifiable credential to be issued.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_subject: Option<HashMap<String, CredentialSubject>>,
+
+    /// An array of claims.display.name values that lists them in the order they should be
+    /// displayed by the Wallet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<Vec<String>>,
+}
+
+/// The following additional claims are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialOffer {
+    /// JSON object containing (and isolating) the detailed description of the credential type. This
+    /// object MUST be processed using full JSON-LD processing.
+    pub credential_definition: CredentialDefinition,
+}
+
+/// The following additional claims are defined for authorization details of type
+/// `openid_credential` and this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationDetails {
+    /// JSON object containing (and isolating) the detailed description of the credential type. This
+    /// object MUST be processed using full JSON-LD processing.
+    pub credential_definition: CredentialDefinition,
+}
+
+/// The following additional claims are defined for authorization details of type
+/// `openid_credential` and this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRequest {
+    /// JSON object containing (and isolating) the detailed description of the credential type. This
+    /// object MUST be processed using full JSON-LD processing.
+    pub credential_definition: CredentialDefinition,
+}
+
+/// JSON object containing (and isolating) the detailed description of the credential type. This
+/// object MUST be processed using full JSON-LD processing.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialDefinition {
+    /// JSON array as defined in [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.1.
+    #[serde(rename = "@context")]
+    pub context: Vec<LinkedDataContext>,
+
+    ///  JSON array designating the types a certain credential type supports according to
+    ///  [VC_DATA](https://www.w3.org/TR/vc-data-model), Section 4.3.
+    pub types: Vec<String>,
+}
+
+/// The value of the credential claim in the Credential Response MUST be a JSON object. Credentials
+/// of this format MUST NOT be re-encoded.
+///
+/// TODO: determine correct inner type
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CredentialResponse(serde_json::Value);
+
+#[cfg(test)]
+mod test_ldp_vc {
+    use crate::types::{
+        credential_issuer_metadata::{CredentialIssuerMetadataFormat, CredentialSupported},
+        ldp_vc,
+    };
+
+    fn valid_ldp_vc_format() -> serde_json::Value {
+        serde_json::json!({
+            "format": "ldp_vc",
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                "https://www.w3.org/2018/credentials/examples/v1"
+            ],
+            "types": [
+                "VerifiableCredential",
+                "UniversityDegreeCredential"
+            ],
+            "cryptographic_binding_methods_supported": [
+                "did"
+            ],
+            "cryptographic_suites_supported": [
+                "Ed25519Signature2018"
+            ],
+            "display": [
+                {
+                    "name": "University Credential",
+                    "locale": "en-US",
+                    "logo": {
+                        "url": "https://exampleuniversity.com/public/logo.png",
+                        "alt_text": "a square logo of a university"
+                    },
+                    "background_color": "#12107c",
+                    "text_color": "#FFFFFF"
+                }
+            ],
+            "credentialSubject": {
+                "given_name": {
+                    "display": [
+                        {
+                            "name": "Given Name",
+                            "locale": "en-US"
+                        }
+                    ]
+                },
+                "last_name": {
+                    "display": [
+                        {
+                            "name": "Surname",
+                            "locale": "en-US"
+                        }
+                    ]
+                },
+                "degree": {},
+                "gpa": {
+                    "display": [
+                        {
+                            "name": "GPA"
+                        }
+                    ]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn should_deserialize_from_example() {
+        let j = valid_ldp_vc_format();
+
+        let ldp_vc_supported_credential: CredentialSupported =
+            serde_json::from_value(j).expect("Unable to deserialize supported credential");
+
+        assert!(matches!(
+            ldp_vc_supported_credential.format,
+            CredentialIssuerMetadataFormat::LdpVc(ldp_vc::CredentialIssuerMetadata { .. })
+        ));
+    }
+
+    #[test]
+    fn should_round_trip() {
+        let j = valid_ldp_vc_format();
+
+        let ldp_vc_supported_credential: CredentialSupported =
+            serde_json::from_value(j.clone()).expect("Unable to deserialize supported credential");
+
+        let j_roundtrip =
+            serde_json::to_value(ldp_vc_supported_credential).expect("Unable to serialize ldp_vc");
+
+        assert_eq!(j, j_roundtrip);
+    }
+}

--- a/crates/openid4vci/src/types/mod.rs
+++ b/crates/openid4vci/src/types/mod.rs
@@ -1,6 +1,9 @@
 /// Module containing a struct for the credential
 pub mod credential;
 
+/// Module containing a struct for the credential offer
+pub mod credential_offer;
+
 /// Module containing a struct for the issuer metadata
 pub mod credential_issuer_metadata;
 
@@ -10,5 +13,20 @@ pub mod credential_request;
 /// Module containing a struct for the authorization server metadata
 pub mod authorization_server_metadata;
 
+/// Module containing structures related ro the grant types
+pub mod grants;
+
 /// Module containing a structure for the token response token type
 pub mod token_type;
+
+/// Module that contains the types associated with the `jwt_vc_json` format
+pub mod jwt_vc_json;
+
+/// Module that contains the types associated with the `jwt_vc_json-ld` format
+pub mod jwt_vc_json_ld;
+
+/// Module that contains the types associated with the `ldp_vc` format
+pub mod ldp_vc;
+
+/// Module that contains the types associated with the `mso_mdoc` format
+pub mod mso_mdoc;

--- a/crates/openid4vci/src/types/mso_mdoc.rs
+++ b/crates/openid4vci/src/types/mso_mdoc.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::credential::CredentialSubject;
+
+/// The Credential format identifier is `mso_mdoc`.
+pub const CREDENTIAL_FORMAT_IDENTIFIER: &str = "mso_mdoc";
+
+/// The following additional Credential Issuer metadata are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialIssuerMetadata {
+    /// JSON string identifying the credential type.
+    pub doctype: String,
+
+    /// A JSON object containing a list of key value pairs, where the key is a certain namespace as
+    /// defined in [ISO.18013-5](https://www.iso.org/standard/69084.html) (or any profile of it),
+    /// and the value is a JSON object. This object also contains a list of key value pairs, where
+    /// the key is a claim that is defined in the respective namespace and is offered in the
+    /// Credential.
+    pub claims: HashMap<String, CredentialSubject>,
+
+    /// An array of claims.display.name values that lists them in the order they should be
+    /// displayed by the Wallet.
+    pub order: Option<Vec<String>>,
+}
+
+/// The following additional claims are defined for this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialOffer {
+    /// JSON string identifying the credential type.
+    pub doctype: String,
+}
+
+/// The following additional claims are defined for authorization details of type
+/// `openid_credential` and this Credential format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationDetails {
+    /// JSON string identifying the credential type.
+    pub doctype: String,
+
+    /// A JSON object containing a list of key value pairs, where the key is a certain namespace as
+    /// defined in [ISO.18013-5](https://www.iso.org/standard/69084.html) (or any profile of it),
+    /// and the value is a JSON object. This object also contains a list of key value pairs, where
+    /// the key is a claim that is defined in the respective namespace and is offered in the
+    /// Credential.
+    pub claims: HashMap<String, CredentialSubject>,
+}
+
+/// The following additional parameters are defined for Credential Requests and this Credential
+/// format.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialRequest {
+    /// JSON string identifying the credential type.
+    pub doctype: String,
+
+    /// A JSON object containing a list of key value pairs, where the key is a certain namespace as
+    /// defined in [ISO.18013-5](https://www.iso.org/standard/69084.html) (or any profile of it),
+    /// and the value is a JSON object. This object also contains a list of key value pairs, where
+    /// the key is a claim that is defined in the respective namespace and is offered in the
+    /// Credential.
+    pub claims: HashMap<String, CredentialSubject>,
+}
+
+/// The value of the credential claim in the Credential Response MUST be a JSON string that is the base64url-encoded representation of the issued Credential.
+pub struct CredentialResponse(String);
+
+impl From<CredentialResponse> for String {
+    fn from(response: CredentialResponse) -> Self {
+        response.0
+    }
+}


### PR DESCRIPTION
## Description

 Created seperate types for the credential issuer metadata, credential request and authorization details (not used for now).

 might need some refactor work so in draft for now.

## Related issue(s)

closes #37

## Checklist

- [ ] Tests (unit, integration and e2e where relevant)
- [ ] Documentation (in docs and within the code)
